### PR TITLE
fix(robots): group consecutive User-agent lines and match agents case…

### DIFF
--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/robots_checker.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/robots_checker.py
@@ -95,6 +95,10 @@ def fetch_robots_txt(url: str, timeout: int = 15) -> dict:
 def _parse_robots(content: str, result: dict):
     """Parse robots.txt content into structured data."""
     current_agents = []
+    # Consecutive User-agent lines form ONE group sharing the rules that follow
+    # (RFC 9309 sec 2.2.1). A rule directive closes the group, so the next
+    # User-agent line starts a new one.
+    in_agent_group = False
 
     for line in content.splitlines():
         line = line.strip()
@@ -112,11 +116,16 @@ def _parse_robots(content: str, result: dict):
         value = value.strip()
 
         if directive == "user-agent":
-            current_agents = [value]
+            if not in_agent_group:
+                current_agents = []
+            in_agent_group = True
+            if value not in current_agents:
+                current_agents.append(value)
             if value not in result["user_agents"]:
                 result["user_agents"][value] = {"allow": [], "disallow": []}
 
         elif directive == "disallow" and current_agents:
+            in_agent_group = False
             for agent in current_agents:
                 if agent not in result["user_agents"]:
                     result["user_agents"][agent] = {"allow": [], "disallow": []}
@@ -124,6 +133,7 @@ def _parse_robots(content: str, result: dict):
                     result["user_agents"][agent]["disallow"].append(value)
 
         elif directive == "allow" and current_agents:
+            in_agent_group = False
             for agent in current_agents:
                 if agent not in result["user_agents"]:
                     result["user_agents"][agent] = {"allow": [], "disallow": []}
@@ -133,18 +143,22 @@ def _parse_robots(content: str, result: dict):
             result["sitemaps"].append(value)
 
         elif directive == "crawl-delay" and current_agents:
+            in_agent_group = False
             for agent in current_agents:
                 try:
                     result["crawl_delays"][agent] = float(value)
                 except ValueError:
                     pass
 
-    # Analyze AI crawler management
-    managed_agents = set(result["user_agents"].keys())
+    # Analyze AI crawler management. User-agent tokens are case-insensitive
+    # (RFC 9309 sec 2.2.1), so match on a folded index while keeping the file's
+    # original casing for display.
+    agents_by_lower = {name.lower(): name for name in result["user_agents"]}
 
     for crawler in AI_CRAWLERS:
-        if crawler in managed_agents:
-            rules = result["user_agents"][crawler]
+        declared = agents_by_lower.get(crawler.lower())
+        if declared is not None:
+            rules = result["user_agents"][declared]
             if rules["disallow"] and "/" in rules["disallow"]:
                 result["ai_crawler_status"][crawler] = "fully blocked"
             elif rules["disallow"]:
@@ -155,8 +169,8 @@ def _parse_robots(content: str, result: dict):
                 result["ai_crawler_status"][crawler] = "declared but no rules"
         else:
             # Check wildcard rules
-            if "*" in managed_agents:
-                wildcard = result["user_agents"]["*"]
+            if "*" in agents_by_lower:
+                wildcard = result["user_agents"][agents_by_lower["*"]]
                 if wildcard["disallow"] and "/" in wildcard["disallow"]:
                     result["ai_crawler_status"][crawler] = "blocked by wildcard (*)"
                 else:

--- a/scripts/robots_checker.py
+++ b/scripts/robots_checker.py
@@ -95,6 +95,10 @@ def fetch_robots_txt(url: str, timeout: int = 15) -> dict:
 def _parse_robots(content: str, result: dict):
     """Parse robots.txt content into structured data."""
     current_agents = []
+    # Consecutive User-agent lines form ONE group sharing the rules that follow
+    # (RFC 9309 sec 2.2.1). A rule directive closes the group, so the next
+    # User-agent line starts a new one.
+    in_agent_group = False
 
     for line in content.splitlines():
         line = line.strip()
@@ -112,11 +116,16 @@ def _parse_robots(content: str, result: dict):
         value = value.strip()
 
         if directive == "user-agent":
-            current_agents = [value]
+            if not in_agent_group:
+                current_agents = []
+            in_agent_group = True
+            if value not in current_agents:
+                current_agents.append(value)
             if value not in result["user_agents"]:
                 result["user_agents"][value] = {"allow": [], "disallow": []}
 
         elif directive == "disallow" and current_agents:
+            in_agent_group = False
             for agent in current_agents:
                 if agent not in result["user_agents"]:
                     result["user_agents"][agent] = {"allow": [], "disallow": []}
@@ -124,6 +133,7 @@ def _parse_robots(content: str, result: dict):
                     result["user_agents"][agent]["disallow"].append(value)
 
         elif directive == "allow" and current_agents:
+            in_agent_group = False
             for agent in current_agents:
                 if agent not in result["user_agents"]:
                     result["user_agents"][agent] = {"allow": [], "disallow": []}
@@ -133,18 +143,22 @@ def _parse_robots(content: str, result: dict):
             result["sitemaps"].append(value)
 
         elif directive == "crawl-delay" and current_agents:
+            in_agent_group = False
             for agent in current_agents:
                 try:
                     result["crawl_delays"][agent] = float(value)
                 except ValueError:
                     pass
 
-    # Analyze AI crawler management
-    managed_agents = set(result["user_agents"].keys())
+    # Analyze AI crawler management. User-agent tokens are case-insensitive
+    # (RFC 9309 sec 2.2.1), so match on a folded index while keeping the file's
+    # original casing for display.
+    agents_by_lower = {name.lower(): name for name in result["user_agents"]}
 
     for crawler in AI_CRAWLERS:
-        if crawler in managed_agents:
-            rules = result["user_agents"][crawler]
+        declared = agents_by_lower.get(crawler.lower())
+        if declared is not None:
+            rules = result["user_agents"][declared]
             if rules["disallow"] and "/" in rules["disallow"]:
                 result["ai_crawler_status"][crawler] = "fully blocked"
             elif rules["disallow"]:
@@ -155,8 +169,8 @@ def _parse_robots(content: str, result: dict):
                 result["ai_crawler_status"][crawler] = "declared but no rules"
         else:
             # Check wildcard rules
-            if "*" in managed_agents:
-                wildcard = result["user_agents"]["*"]
+            if "*" in agents_by_lower:
+                wildcard = result["user_agents"][agents_by_lower["*"]]
                 if wildcard["disallow"] and "/" in wildcard["disallow"]:
                     result["ai_crawler_status"][crawler] = "blocked by wildcard (*)"
                 else:

--- a/tests/test_robots_checker.py
+++ b/tests/test_robots_checker.py
@@ -1,0 +1,98 @@
+"""Tests for robots.txt group parsing and user-agent matching.
+
+Covers RFC 9309 sec 2.2.1: consecutive User-agent lines form one group that
+shares the rules following them, and user-agent tokens match case-insensitively.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from robots_checker import _parse_robots  # noqa: E402
+
+
+def parse(content):
+    result = {
+        "user_agents": {},
+        "sitemaps": [],
+        "crawl_delays": {},
+        "ai_crawler_status": {},
+        "issues": [],
+        "recommendations": [],
+    }
+    _parse_robots(content, result)
+    return result
+
+
+def test_consecutive_user_agents_share_following_rules():
+    """The canonical AI-blocking block: one Disallow under stacked agents."""
+    result = parse(
+        "User-agent: GPTBot\n"
+        "User-agent: CCBot\n"
+        "User-agent: ClaudeBot\n"
+        "Disallow: /\n"
+    )
+
+    for agent in ("GPTBot", "CCBot", "ClaudeBot"):
+        assert result["user_agents"][agent]["disallow"] == ["/"], (
+            f"{agent} lost its Disallow; consecutive User-agent lines must "
+            f"form one group"
+        )
+        assert result["ai_crawler_status"][agent] == "fully blocked"
+
+
+def test_rule_directive_closes_the_group():
+    """A new User-agent after a rule starts a fresh group, not an addition."""
+    result = parse(
+        "User-agent: GPTBot\n"
+        "Disallow: /private\n"
+        "User-agent: CCBot\n"
+        "Disallow: /other\n"
+    )
+
+    assert result["user_agents"]["GPTBot"]["disallow"] == ["/private"]
+    assert result["user_agents"]["CCBot"]["disallow"] == ["/other"]
+
+
+def test_crawl_delay_applies_to_every_agent_in_the_group():
+    result = parse("User-agent: GPTBot\nUser-agent: CCBot\nCrawl-delay: 10\n")
+
+    assert result["crawl_delays"]["GPTBot"] == 10.0
+    assert result["crawl_delays"]["CCBot"] == 10.0
+
+
+def test_repeated_agent_in_one_group_is_not_duplicated():
+    result = parse("User-agent: GPTBot\nUser-agent: GPTBot\nDisallow: /\n")
+
+    assert result["user_agents"]["GPTBot"]["disallow"] == ["/"]
+
+
+@pytest.mark.parametrize("declared", ["gptbot", "GPTBOT", "GptBot"])
+def test_user_agent_matching_is_case_insensitive(declared):
+    """RFC 9309: user-agent tokens are matched case-insensitively."""
+    result = parse(f"User-agent: {declared}\nDisallow: /\n")
+
+    assert result["ai_crawler_status"]["GPTBot"] == "fully blocked"
+
+
+def test_wildcard_group_still_resolves_for_undeclared_crawlers():
+    result = parse("User-agent: *\nDisallow: /\n")
+
+    assert result["ai_crawler_status"]["GPTBot"] == "blocked by wildcard (*)"
+
+
+def test_sitemap_does_not_break_an_open_agent_group():
+    """Sitemap is a non-group directive and must not split stacked agents."""
+    result = parse(
+        "User-agent: GPTBot\n"
+        "Sitemap: https://example.com/sitemap.xml\n"
+        "User-agent: CCBot\n"
+        "Disallow: /\n"
+    )
+
+    assert result["sitemaps"] == ["https://example.com/sitemap.xml"]
+    assert result["user_agents"]["GPTBot"]["disallow"] == ["/"]
+    assert result["user_agents"]["CCBot"]["disallow"] == ["/"]


### PR DESCRIPTION
…-insensitively

Two RFC 9309 sec 2.2.1 conformance bugs in _parse_robots, both of which fire on the canonical AI-crawler block this checker exists to read.

1. Consecutive User-agent lines did not form a group. `current_agents = [value]` replaced the list on every User-agent line, so given

       User-agent: GPTBot
       User-agent: CCBot
       User-agent: ClaudeBot
       Disallow: /

   only ClaudeBot received the rule; GPTBot and CCBot were reported as "not managed (allowed by default)" on a site that had in fact blocked them. Consecutive User-agent lines now accumulate, and a rule directive closes the group so the next User-agent starts a fresh one.

2. Agent matching was case-sensitive. RFC 9309 specifies case-insensitive user-agent tokens, so `User-agent: gptbot` read as unmanaged. Matching now goes through a folded index while the file's original casing is preserved for display.

Adds tests/test_robots_checker.py (9 tests). Six of them fail against the current parser and all nine pass with this change.