### PR TITLE
fix: validate URLs before fetching in link_profile and redirect_checker

### DIFF
--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/link_profile.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/link_profile.py
@@ -31,6 +31,8 @@ except ImportError:
           file=sys.stderr)
     sys.exit(1)
 
+from url_safety import validate_url
+
 
 USER_AGENT = "Mozilla/5.0 (compatible; UltimateSEO-LinkProfile/1.8)"
 
@@ -40,9 +42,21 @@ USER_AGENT = "Mozilla/5.0 (compatible; UltimateSEO-LinkProfile/1.8)"
 # ---------------------------------------------------------------------------
 
 def fetch_page(url: str, timeout: int = 10) -> tuple:
-    """Return (final_url, html) or (url, '')."""
+    """Return (final_url, html) or (url, '').
+
+    Most URLs reaching this function come from the audited site itself: the
+    <loc> entries of its sitemap and the hrefs of its pages. urlopen serves
+    file:// and ftp:// as happily as http://, so without a scheme check a
+    sitemap entry of <loc>file:///etc/passwd</loc> is read straight into the
+    report. validate_url is the guard this repo already ships for that.
+    """
+    safe = validate_url(url)
+    if not safe.ok:
+        return url, ""
     try:
-        req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+        req = urllib.request.Request(
+            safe.normalized_url, headers={"User-Agent": USER_AGENT}
+        )
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             return resp.url, resp.read().decode("utf-8", errors="ignore")
     except Exception:

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/redirect_checker.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/redirect_checker.py
@@ -22,6 +22,8 @@ except ImportError:
     sys.exit(1)
 
 
+from url_safety import validate_url
+
 HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; UltimateSEO/1.8)"}
 
 
@@ -64,8 +66,30 @@ def check_redirects(url: str, max_redirects: int = 10, timeout: int = 10) -> dic
                 break
             seen.add(current)
 
-            resp = requests.head(current, timeout=timeout, headers=HEADERS,
-                                 allow_redirects=False)
+            # Re-validate EVERY hop, not just the seed. `current` is taken from
+            # the previous response's Location header below, so an audited host
+            # can steer this loop wherever it likes: one
+            # `302 Location: http://169.254.169.254/latest/meta-data/` reaches
+            # cloud metadata, and each hop's status and timing is recorded in
+            # result["chain"]. This mirrors the per-hop check fetch_page.py does.
+            safe = validate_url(current)
+            if not safe.ok:
+                result["issues"].append(
+                    f"🔴 Refused to follow step {i+1}: {safe.reason} ({current})"
+                )
+                # Same key shape as a normal hop; downstream readers index
+                # status/time_ms directly.
+                result["chain"].append({
+                    "step": i + 1,
+                    "url": current,
+                    "status": None,
+                    "time_ms": 0,
+                    "blocked": safe.reason,
+                })
+                break
+
+            resp = requests.head(safe.normalized_url, timeout=timeout,
+                                 headers=HEADERS, allow_redirects=False)
 
             hop = {
                 "step": i + 1,

--- a/scripts/link_profile.py
+++ b/scripts/link_profile.py
@@ -31,6 +31,8 @@ except ImportError:
           file=sys.stderr)
     sys.exit(1)
 
+from url_safety import validate_url
+
 
 USER_AGENT = "Mozilla/5.0 (compatible; UltimateSEO-LinkProfile/1.8)"
 
@@ -40,9 +42,21 @@ USER_AGENT = "Mozilla/5.0 (compatible; UltimateSEO-LinkProfile/1.8)"
 # ---------------------------------------------------------------------------
 
 def fetch_page(url: str, timeout: int = 10) -> tuple:
-    """Return (final_url, html) or (url, '')."""
+    """Return (final_url, html) or (url, '').
+
+    Most URLs reaching this function come from the audited site itself: the
+    <loc> entries of its sitemap and the hrefs of its pages. urlopen serves
+    file:// and ftp:// as happily as http://, so without a scheme check a
+    sitemap entry of <loc>file:///etc/passwd</loc> is read straight into the
+    report. validate_url is the guard this repo already ships for that.
+    """
+    safe = validate_url(url)
+    if not safe.ok:
+        return url, ""
     try:
-        req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+        req = urllib.request.Request(
+            safe.normalized_url, headers={"User-Agent": USER_AGENT}
+        )
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             return resp.url, resp.read().decode("utf-8", errors="ignore")
     except Exception:

--- a/scripts/redirect_checker.py
+++ b/scripts/redirect_checker.py
@@ -22,6 +22,8 @@ except ImportError:
     sys.exit(1)
 
 
+from url_safety import validate_url
+
 HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; UltimateSEO/1.8)"}
 
 
@@ -64,8 +66,30 @@ def check_redirects(url: str, max_redirects: int = 10, timeout: int = 10) -> dic
                 break
             seen.add(current)
 
-            resp = requests.head(current, timeout=timeout, headers=HEADERS,
-                                 allow_redirects=False)
+            # Re-validate EVERY hop, not just the seed. `current` is taken from
+            # the previous response's Location header below, so an audited host
+            # can steer this loop wherever it likes: one
+            # `302 Location: http://169.254.169.254/latest/meta-data/` reaches
+            # cloud metadata, and each hop's status and timing is recorded in
+            # result["chain"]. This mirrors the per-hop check fetch_page.py does.
+            safe = validate_url(current)
+            if not safe.ok:
+                result["issues"].append(
+                    f"🔴 Refused to follow step {i+1}: {safe.reason} ({current})"
+                )
+                # Same key shape as a normal hop; downstream readers index
+                # status/time_ms directly.
+                result["chain"].append({
+                    "step": i + 1,
+                    "url": current,
+                    "status": None,
+                    "time_ms": 0,
+                    "blocked": safe.reason,
+                })
+                break
+
+            resp = requests.head(safe.normalized_url, timeout=timeout,
+                                 headers=HEADERS, allow_redirects=False)
 
             hop = {
                 "step": i + 1,

--- a/tests/test_fetch_url_validation.py
+++ b/tests/test_fetch_url_validation.py
@@ -1,0 +1,133 @@
+"""Both fetchers must validate URLs they did not choose themselves.
+
+link_profile fetches the <loc> entries of the audited site's sitemap and the
+hrefs of its pages. redirect_checker follows the Location header of whatever it
+just fetched. In both cases the audited host picks the next URL, so the guard
+has to run on every request rather than only on the seed.
+"""
+
+import os
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import link_profile  # noqa: E402
+import redirect_checker  # noqa: E402
+
+
+@pytest.fixture
+def secret_file():
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as fh:
+        fh.write("SUPER_SECRET_CONTENTS")
+        path = fh.name
+    yield path
+    os.unlink(path)
+
+
+# --- link_profile.fetch_page ------------------------------------------------
+
+def test_file_scheme_is_refused(secret_file):
+    """A sitemap <loc> of file:///... must not read local disk."""
+    _, body = link_profile.fetch_page(f"file://{secret_file}")
+
+    assert "SUPER_SECRET_CONTENTS" not in body
+    assert body == ""
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:///etc/passwd",
+        "ftp://example.com/x",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://127.0.0.1:8080/admin",
+        "http://localhost/admin",
+        "http://[::1]/admin",
+        "http://10.0.0.5/internal",
+        "http://user:pass@example.com/",
+        "http://2130706433/",  # decimal-encoded 127.0.0.1
+    ],
+)
+def test_unsafe_targets_return_empty(url):
+    final_url, body = link_profile.fetch_page(url)
+
+    assert body == "", f"{url} should not have been fetched"
+    assert final_url == url
+
+
+def test_ordinary_https_url_is_not_rejected_by_the_guard(monkeypatch):
+    """The guard must not block normal targets; network itself is stubbed."""
+    seen = {}
+
+    class FakeResponse:
+        url = "https://example.com/"
+
+        def read(self):
+            return b"<html>ok</html>"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def fake_urlopen(req, timeout=None):
+        seen["url"] = req.full_url
+        return FakeResponse()
+
+    monkeypatch.setattr(link_profile.urllib.request, "urlopen", fake_urlopen)
+
+    final_url, body = link_profile.fetch_page("https://example.com/")
+
+    assert body == "<html>ok</html>"
+    assert seen["url"].startswith("https://example.com")
+
+
+# --- redirect_checker per-hop validation ------------------------------------
+
+class FakeHeadResponse:
+    def __init__(self, status_code, location=None):
+        self.status_code = status_code
+        self.headers = {"Location": location} if location else {}
+        self.elapsed = __import__("datetime").timedelta(milliseconds=5)
+
+
+def test_redirect_to_metadata_endpoint_is_refused(monkeypatch):
+    """One 302 must not walk the checker into cloud metadata."""
+    responses = [
+        FakeHeadResponse(302, "http://169.254.169.254/latest/meta-data/"),
+        FakeHeadResponse(200),
+    ]
+    calls = []
+
+    def fake_head(url, **kwargs):
+        calls.append(url)
+        return responses.pop(0)
+
+    monkeypatch.setattr(redirect_checker.requests, "head", fake_head)
+
+    result = redirect_checker.check_redirects("https://example.com/")
+
+    assert not any("169.254.169.254" in c for c in calls), (
+        f"followed the hop into link-local space: {calls}"
+    )
+    assert any("Refused to follow" in i for i in result["issues"]), result["issues"]
+
+
+def test_ordinary_redirect_chain_still_followed(monkeypatch):
+    responses = [
+        FakeHeadResponse(301, "https://example.com/new"),
+        FakeHeadResponse(200),
+    ]
+
+    monkeypatch.setattr(
+        redirect_checker.requests, "head", lambda url, **kw: responses.pop(0)
+    )
+
+    result = redirect_checker.check_redirects("https://example.com/old")
+
+    assert result["final_url"] == "https://example.com/new"
+    assert not result["issues"], result["issues"]


### PR DESCRIPTION
Both of these fetch URLs chosen by the **audited host** rather than by the operator, so `url_safety.validate_url` (which this repo already ships, and which handles the hard cases well) needs to run on each request. It is currently imported by 5 of the 49 scripts; these two are where the URL provenance is attacker-controlled and the result is echoed back into the report.

### `link_profile.fetch_page`

Wraps `urllib.request.urlopen` with no scheme check. Its inputs are the `<loc>` entries of the target's sitemap (`get_sitemap_urls`) plus hrefs harvested from crawled pages. `urlopen` serves `file://` and `ftp://`, so a sitemap containing `<loc>file:///etc/passwd</loc>` has that file read and folded into the analysis. This path runs by default via `generate_report.py`.

### `redirect_checker.check_redirects`

Validated nothing and reassigned `current` from each response's `Location` header, so a single `302 Location: http://169.254.169.254/latest/meta-data/` walked it into cloud metadata, with per-hop status and timing recorded in `result["chain"]`. Every hop is now re-validated, matching the loop `fetch_page.py` already uses. A refused hop is appended with the same key shape as a normal hop so downstream readers are unaffected.

### Tests

Adds `tests/test_fetch_url_validation.py`, 13 tests. Three fail against `main`, including one asserting that a local file's contents do not reach the caller.

Incidental: the suite runs in 0.13s with the guard and 30s without, because the unguarded version genuinely dials `169.254.169.254` and localhost and waits for timeouts.

Plugin mirror synced, `check-plugin-sync.py` passes.