### PR TITLE
fix: three independent one-line defects (drift severity, LA region, p…

### DIFF
--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/drift_monitor.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/drift_monitor.py
@@ -189,7 +189,7 @@ def _apply_rules(previous: dict, current: dict) -> list[dict]:
     old_robots = previous.get("robots", "")
     new_robots = current.get("robots", "")
     if old_robots != new_robots:
-        sev = "critical" if "noindex" in (new_robots or "").lower() else "critical"
+        sev = "critical" if "noindex" in (new_robots or "").lower() else "warning"
         desc = "Robots meta changed to noindex" if "noindex" in (new_robots or "").lower() else "Robots meta directive changed"
         changes.append({
             "rule": 3,

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/entity_checker.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/entity_checker.py
@@ -245,6 +245,24 @@ def check_wikipedia(entity_name: str) -> dict:
 # NAP consistency check
 # ---------------------------------------------------------------------------
 
+# A phone-shaped run of characters. Kept separate from the digit count below so
+# the two conditions stay independently readable.
+_PHONE_CANDIDATE_RE = re.compile(r"\+?\d[\d\-\(\)\.\s]{5,18}\d")
+
+
+def has_visible_phone(page_text: str) -> bool:
+    """True when the page shows something that could be a phone number.
+
+    A candidate run must carry at least 7 actual digits. The original
+    expression put ``\\s`` inside the character class with no digit floor, so
+    seven consecutive spaces matched and the check returned True on every page.
+    """
+    return any(
+        len(re.sub(r"\D", "", candidate)) >= 7
+        for candidate in _PHONE_CANDIDATE_RE.findall(page_text)
+    )
+
+
 def check_nap_consistency(soup: BeautifulSoup, entities: list) -> list:
     """Check Name/Address/Phone consistency signals on the page."""
     issues = []
@@ -266,7 +284,7 @@ def check_nap_consistency(soup: BeautifulSoup, entities: list) -> list:
 
     # Check for visible phone/address on page
     page_text = soup.get_text(separator=" ")
-    has_phone = bool(re.search(r"[\+]?[\d\-\(\)\s]{7,15}", page_text))
+    has_phone = has_visible_phone(page_text)
     has_address = bool(re.search(r"\d{1,5}\s+\w+\s+(street|st|avenue|ave|road|rd|blvd|drive|dr|lane|ln)", page_text, re.I))
 
     if not has_phone and local_entities:

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/hreflang_checker.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/hreflang_checker.py
@@ -90,8 +90,10 @@ VALID_REGION_CODES = {
 # Common region mistakes
 COMMON_REGION_MISTAKES = {
     "UK": "GB",   # UK is not a valid ISO 3166-1 code; use GB
-    "LA": None,   # Latin America is not a country
     "EU": None,   # European Union is not a country
+    # NOTE: "LA" is NOT listed here. It is the ISO 3166-1 code for Laos and is
+    # present in VALID_REGION_CODES; treating it as the "Latin America" mistake
+    # made every valid lo-LA / en-LA tag fail.
 }
 
 USER_AGENT = "Mozilla/5.0 (compatible; UltimateSEO-hreflang/1.8)"

--- a/scripts/drift_monitor.py
+++ b/scripts/drift_monitor.py
@@ -189,7 +189,7 @@ def _apply_rules(previous: dict, current: dict) -> list[dict]:
     old_robots = previous.get("robots", "")
     new_robots = current.get("robots", "")
     if old_robots != new_robots:
-        sev = "critical" if "noindex" in (new_robots or "").lower() else "critical"
+        sev = "critical" if "noindex" in (new_robots or "").lower() else "warning"
         desc = "Robots meta changed to noindex" if "noindex" in (new_robots or "").lower() else "Robots meta directive changed"
         changes.append({
             "rule": 3,

--- a/scripts/entity_checker.py
+++ b/scripts/entity_checker.py
@@ -245,6 +245,24 @@ def check_wikipedia(entity_name: str) -> dict:
 # NAP consistency check
 # ---------------------------------------------------------------------------
 
+# A phone-shaped run of characters. Kept separate from the digit count below so
+# the two conditions stay independently readable.
+_PHONE_CANDIDATE_RE = re.compile(r"\+?\d[\d\-\(\)\.\s]{5,18}\d")
+
+
+def has_visible_phone(page_text: str) -> bool:
+    """True when the page shows something that could be a phone number.
+
+    A candidate run must carry at least 7 actual digits. The original
+    expression put ``\\s`` inside the character class with no digit floor, so
+    seven consecutive spaces matched and the check returned True on every page.
+    """
+    return any(
+        len(re.sub(r"\D", "", candidate)) >= 7
+        for candidate in _PHONE_CANDIDATE_RE.findall(page_text)
+    )
+
+
 def check_nap_consistency(soup: BeautifulSoup, entities: list) -> list:
     """Check Name/Address/Phone consistency signals on the page."""
     issues = []
@@ -266,7 +284,7 @@ def check_nap_consistency(soup: BeautifulSoup, entities: list) -> list:
 
     # Check for visible phone/address on page
     page_text = soup.get_text(separator=" ")
-    has_phone = bool(re.search(r"[\+]?[\d\-\(\)\s]{7,15}", page_text))
+    has_phone = has_visible_phone(page_text)
     has_address = bool(re.search(r"\d{1,5}\s+\w+\s+(street|st|avenue|ave|road|rd|blvd|drive|dr|lane|ln)", page_text, re.I))
 
     if not has_phone and local_entities:

--- a/scripts/hreflang_checker.py
+++ b/scripts/hreflang_checker.py
@@ -90,8 +90,10 @@ VALID_REGION_CODES = {
 # Common region mistakes
 COMMON_REGION_MISTAKES = {
     "UK": "GB",   # UK is not a valid ISO 3166-1 code; use GB
-    "LA": None,   # Latin America is not a country
     "EU": None,   # European Union is not a country
+    # NOTE: "LA" is NOT listed here. It is the ISO 3166-1 code for Laos and is
+    # present in VALID_REGION_CODES; treating it as the "Latin America" mistake
+    # made every valid lo-LA / en-LA tag fail.
 }
 
 USER_AGENT = "Mozilla/5.0 (compatible; UltimateSEO-hreflang/1.8)"

--- a/tests/test_verified_one_liners.py
+++ b/tests/test_verified_one_liners.py
@@ -1,0 +1,92 @@
+"""Regression tests for three independent one-line defects.
+
+Each test fails against the code as it stood before the accompanying fix.
+"""
+
+import os
+import re
+import sys
+
+from bs4 import BeautifulSoup
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import drift_monitor  # noqa: E402
+import entity_checker  # noqa: E402
+import hreflang_checker  # noqa: E402
+
+
+# --- drift_monitor: robots-meta severity was a tautology --------------------
+
+def _robots_change(old, new):
+    changes = drift_monitor._apply_rules({"robots": old}, {"robots": new})
+    return next(c for c in changes if c["rule"] == 3)
+
+
+def test_noindex_addition_is_critical():
+    assert _robots_change("index,follow", "noindex,follow")["severity"] == "critical"
+
+
+def test_benign_robots_change_is_not_critical():
+    """`max-image-preview:large` is Google's own recommendation, not an outage."""
+    change = _robots_change(
+        "index,follow", "index,follow,max-image-preview:large"
+    )
+
+    assert change["severity"] == "warning"
+    assert change["severity"] in drift_monitor.SEVERITY_ORDER
+
+
+# --- hreflang: LA is Laos, not "Latin America" ------------------------------
+
+def test_la_is_a_valid_iso_region():
+    assert "LA" in hreflang_checker.VALID_REGION_CODES
+    assert "LA" not in hreflang_checker.COMMON_REGION_MISTAKES
+
+
+def test_lo_la_validates_clean():
+    result = hreflang_checker.validate_lang_code("lo-LA")
+
+    assert result["valid"] is True, result
+    assert result["region"] == "LA"
+
+
+def test_genuine_region_mistakes_still_flagged():
+    assert hreflang_checker.validate_lang_code("en-UK")["valid"] is False
+    assert hreflang_checker.validate_lang_code("en-EU")["valid"] is False
+
+
+# --- entity_checker: phone detection matched whitespace ---------------------
+
+_has_phone = entity_checker.has_visible_phone
+
+
+def test_whitespace_is_not_a_phone_number():
+    """The old class included \\s, so 7 spaces satisfied it on every page."""
+    assert _has_phone("Contact       us today") is False
+
+
+def test_prose_without_digits_is_not_a_phone_number():
+    assert _has_phone("We are open Monday through Friday.") is False
+
+
+def test_real_phone_numbers_are_still_detected():
+    for number in ("(512) 555-0134", "+1 512 555 0134", "512-555-0134"):
+        assert _has_phone(f"Call {number} today") is True, number
+
+
+def test_nap_check_reports_a_missing_phone():
+    """End to end through check_nap_consistency, which the bug made dead."""
+    soup = BeautifulSoup("<p>Contact       us today</p>", "html.parser")
+    entities = [{"type": "LocalBusiness"}]
+
+    issues = entity_checker.check_nap_consistency(soup, entities)
+
+    assert any("phone" in str(i).lower() for i in issues), (
+        "a LocalBusiness page with no phone number must raise a NAP issue; "
+        f"got {issues}"
+    )
+    assert re.search(r"[\+]?[\d\-\(\)\s]{7,15}", soup.get_text(separator=" ")), (
+        "the old expression matched this whitespace-only text, which is why "
+        "the check was dead"
+    )


### PR DESCRIPTION
…hone detection)

Unrelated to each other but each a single wrong expression, so grouped for review rather than split across three PRs.

1. drift_monitor._apply_rules rule 3 severity was a tautology: `sev = "critical" if "noindex" in ... else "critical"` Every robots-meta change was critical, so adding Google's own recommended max-image-preview:large raised a critical alert. The else branch is now "warning", which is already in SEVERITY_ORDER and used by 15 other rules.

2. hreflang_checker.COMMON_REGION_MISTAKES mapped "LA" to None with the comment "Latin America is not a country". LA is the ISO 3166-1 code for Laos and is already present in VALID_REGION_CODES, but the mistakes table is consulted first, so every lo-LA / en-LA tag was reported invalid. Entry removed; UK and EU still flagged.

3. entity_checker phone detection: `[\+]?[\d\-\(\)\s]{7,15}` put \s inside the class with no digit floor, so seven consecutive spaces matched and has_phone was True on every page, making the "LocalBusiness with no visible phone" issue unreachable. Extracted to has_visible_phone() so it is testable, and a candidate run now needs at least 7 real digits.

Adds tests/test_verified_one_liners.py (9 tests).