### PR TITLE
fix(schema): extract JSON-LD with any tag attributes; stop two false criticals

### DIFF
--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/validate_schema.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/validate_schema.py
@@ -19,7 +19,14 @@ from typing import List
 def validate_jsonld(content: str) -> List[str]:
     """Validate JSON-LD blocks in HTML content."""
     errors = []
-    pattern = r'<script\s+type=["\']application/ld\+json["\']\s*>(.*?)</script>'
+    # `type` may sit anywhere in the tag and is rarely the only attribute:
+    # Yoast emits class="yoast-schema-graph", Next.js and Shopify commonly add
+    # id=. Requiring `type` to be the sole attribute silently extracted nothing
+    # on those sites and returned a clean bill of health.
+    pattern = (
+        r'<script\b[^>]*?\btype\s*=\s*["\']application/ld\+json["\'][^>]*>'
+        r'(.*?)</script>'
+    )
     blocks = re.findall(pattern, content, re.DOTALL | re.IGNORECASE)
 
     if not blocks:
@@ -38,23 +45,36 @@ def validate_jsonld(content: str) -> List[str]:
                 errors.extend(_validate_schema_object(item, i))
         elif isinstance(data, dict):
             if "@graph" in data and isinstance(data["@graph"], list):
+                # Graph members inherit @context from the wrapper; only the
+                # wrapper is required to declare it (JSON-LD 1.1 sec 4.9).
                 for item in data["@graph"]:
                     if isinstance(item, dict):
-                        errors.extend(_validate_schema_object(item, i))
+                        errors.extend(
+                            _validate_schema_object(item, i, require_context=False)
+                        )
+                if "@context" not in data:
+                    errors.append(f"Block {i}: Missing @context")
             else:
                 errors.extend(_validate_schema_object(data, i))
 
     return errors
 
 
-def _validate_schema_object(obj: dict, block_num: int) -> List[str]:
-    """Validate a single schema object."""
+def _validate_schema_object(
+    obj: dict, block_num: int, require_context: bool = True
+) -> List[str]:
+    """Validate a single schema object.
+
+    ``require_context`` is False for @graph members, which inherit the
+    wrapper's context rather than declaring their own.
+    """
     errors = []
     prefix = f"Block {block_num}"
 
     # Check @context
     if "@context" not in obj:
-        errors.append(f"{prefix}: Missing @context")
+        if require_context:
+            errors.append(f"{prefix}: Missing @context")
     elif obj["@context"] not in ("https://schema.org", "http://schema.org"):
         errors.append(f"{prefix}: @context should be 'https://schema.org'")
 
@@ -70,7 +90,13 @@ def _validate_schema_object(obj: dict, block_num: int) -> List[str]:
         "[Address]",
         "[Your",
         "[INSERT",
-        "REPLACE",
+        # Was the bare string "REPLACE", matched case-insensitively against the
+        # whole serialized object, so an article headlined "How to Replace a
+        # Faucet" was reported as containing placeholder text — which
+        # _is_critical() treats as critical and main() exits 2 on.
+        "[REPLACE",
+        "REPLACE_ME",
+        "REPLACE WITH",
         "[URL]",
         "[Email]",
     ]

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -19,7 +19,14 @@ from typing import List
 def validate_jsonld(content: str) -> List[str]:
     """Validate JSON-LD blocks in HTML content."""
     errors = []
-    pattern = r'<script\s+type=["\']application/ld\+json["\']\s*>(.*?)</script>'
+    # `type` may sit anywhere in the tag and is rarely the only attribute:
+    # Yoast emits class="yoast-schema-graph", Next.js and Shopify commonly add
+    # id=. Requiring `type` to be the sole attribute silently extracted nothing
+    # on those sites and returned a clean bill of health.
+    pattern = (
+        r'<script\b[^>]*?\btype\s*=\s*["\']application/ld\+json["\'][^>]*>'
+        r'(.*?)</script>'
+    )
     blocks = re.findall(pattern, content, re.DOTALL | re.IGNORECASE)
 
     if not blocks:
@@ -38,23 +45,36 @@ def validate_jsonld(content: str) -> List[str]:
                 errors.extend(_validate_schema_object(item, i))
         elif isinstance(data, dict):
             if "@graph" in data and isinstance(data["@graph"], list):
+                # Graph members inherit @context from the wrapper; only the
+                # wrapper is required to declare it (JSON-LD 1.1 sec 4.9).
                 for item in data["@graph"]:
                     if isinstance(item, dict):
-                        errors.extend(_validate_schema_object(item, i))
+                        errors.extend(
+                            _validate_schema_object(item, i, require_context=False)
+                        )
+                if "@context" not in data:
+                    errors.append(f"Block {i}: Missing @context")
             else:
                 errors.extend(_validate_schema_object(data, i))
 
     return errors
 
 
-def _validate_schema_object(obj: dict, block_num: int) -> List[str]:
-    """Validate a single schema object."""
+def _validate_schema_object(
+    obj: dict, block_num: int, require_context: bool = True
+) -> List[str]:
+    """Validate a single schema object.
+
+    ``require_context`` is False for @graph members, which inherit the
+    wrapper's context rather than declaring their own.
+    """
     errors = []
     prefix = f"Block {block_num}"
 
     # Check @context
     if "@context" not in obj:
-        errors.append(f"{prefix}: Missing @context")
+        if require_context:
+            errors.append(f"{prefix}: Missing @context")
     elif obj["@context"] not in ("https://schema.org", "http://schema.org"):
         errors.append(f"{prefix}: @context should be 'https://schema.org'")
 
@@ -70,7 +90,13 @@ def _validate_schema_object(obj: dict, block_num: int) -> List[str]:
         "[Address]",
         "[Your",
         "[INSERT",
-        "REPLACE",
+        # Was the bare string "REPLACE", matched case-insensitively against the
+        # whole serialized object, so an article headlined "How to Replace a
+        # Faucet" was reported as containing placeholder text — which
+        # _is_critical() treats as critical and main() exits 2 on.
+        "[REPLACE",
+        "REPLACE_ME",
+        "REPLACE WITH",
         "[URL]",
         "[Email]",
     ]

--- a/tests/test_validate_schema.py
+++ b/tests/test_validate_schema.py
@@ -1,0 +1,131 @@
+"""Tests for JSON-LD extraction and placeholder detection.
+
+Each test below fails against the code as it stood before the accompanying fix.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from validate_schema import validate_jsonld  # noqa: E402
+
+
+def page(script_tag_attrs, payload):
+    return (
+        f"<html><head><script {script_tag_attrs}>"
+        f"{json.dumps(payload)}"
+        f"</script></head><body></body></html>"
+    )
+
+
+VALID = {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "A perfectly ordinary headline",
+}
+
+BROKEN = {"@context": "https://schema.org"}  # no @type
+
+
+# --- extraction: `type` is rarely the only attribute ------------------------
+
+@pytest.mark.parametrize(
+    "attrs",
+    [
+        'type="application/ld+json"',
+        'type="application/ld+json" id="schema"',
+        'id="schema" type="application/ld+json"',
+        'type="application/ld+json" class="yoast-schema-graph"',
+        "type='application/ld+json' data-nscript='beforeInteractive'",
+        'type = "application/ld+json"',
+    ],
+)
+def test_blocks_are_extracted_regardless_of_other_attributes(attrs):
+    """A missed block reports zero errors, which reads as a clean site."""
+    errors = validate_jsonld(page(attrs, BROKEN))
+
+    assert any("Missing @type" in e for e in errors), (
+        f"schema in <script {attrs}> was not extracted, so its defect was "
+        f"invisible; got {errors}"
+    )
+
+
+def test_valid_schema_still_produces_no_errors():
+    assert validate_jsonld(page('type="application/ld+json" id="x"', VALID)) == []
+
+
+def test_non_jsonld_script_tags_are_ignored():
+    html = '<html><script type="text/javascript">var x = 1;</script></html>'
+
+    assert validate_jsonld(html) == []
+
+
+# --- @graph members inherit the wrapper's @context --------------------------
+
+def test_graph_members_do_not_each_need_a_context():
+    """The Yoast/WordPress shape: one wrapper context, many member nodes."""
+    graph = {
+        "@context": "https://schema.org",
+        "@graph": [
+            {"@type": "Organization", "name": "Example"},
+            {"@type": "WebSite", "name": "Example"},
+            {"@type": "WebPage", "name": "Home"},
+        ],
+    }
+
+    errors = validate_jsonld(page('type="application/ld+json"', graph))
+
+    assert errors == [], f"graph members were each asked for @context: {errors}"
+
+
+def test_graph_wrapper_without_context_is_still_reported_once():
+    graph = {"@graph": [{"@type": "Organization", "name": "Example"}]}
+
+    errors = validate_jsonld(page('type="application/ld+json"', graph))
+
+    assert [e for e in errors if "Missing @context" in e] == [
+        "Block 1: Missing @context"
+    ], errors
+
+
+# --- placeholder detection must not fire on ordinary prose ------------------
+
+@pytest.mark.parametrize(
+    "headline",
+    [
+        "How to Replace a Faucet",
+        "When to replace your roof",
+        "Replace vs. repair: a buyer's guide",
+    ],
+)
+def test_ordinary_prose_containing_replace_is_not_a_placeholder(headline):
+    """Placeholder findings are critical and exit 2, so a false one blocks."""
+    payload = dict(VALID, headline=headline)
+
+    errors = validate_jsonld(page('type="application/ld+json"', payload))
+
+    assert errors == [], f"'{headline}' was flagged as placeholder text: {errors}"
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["[REPLACE with your business name]", "REPLACE_ME", "REPLACE WITH YOUR URL"],
+)
+def test_real_placeholder_scaffolding_is_still_caught(value):
+    payload = dict(VALID, headline=value)
+
+    errors = validate_jsonld(page('type="application/ld+json"', payload))
+
+    assert any("placeholder" in e.lower() for e in errors), errors
+
+
+def test_bracketed_placeholders_still_caught():
+    payload = dict(VALID, publisher={"@type": "Organization", "name": "[Business Name]"})
+
+    errors = validate_jsonld(page('type="application/ld+json"', payload))
+
+    assert any("placeholder" in e.lower() for e in errors), errors


### PR DESCRIPTION
Three defects in `validate_schema.py`. The first hides real errors; the other two invent errors.

### 1. Extraction missed most real-world JSON-LD

```python
pattern = r'<script\s+type=["\']application/ld\+json["\']\s*>(.*?)</script>'
```

`type` has to be the only attribute on the tag. In practice it rarely is:

| Tag | Extracted today |
|---|---|
| `<script type="application/ld+json">` | yes |
| `<script type="application/ld+json" id="schema">` | **no** |
| `<script type="application/ld+json" class="yoast-schema-graph">` | **no** |

On those pages extraction returns nothing and hits `return []  # No schema found — not an error`. Meanwhile the separate block **counter** around line 168 uses a looser pattern, so `--json` reports blocks found alongside zero errors and a clean score on a page where nothing was validated.

### 2. `@graph` members were each required to declare `@context`

Members inherit it from the wrapper (JSON-LD 1.1 §4.9); only the wrapper declares it. A Yoast-style graph of 6 to 10 nodes therefore produced 6 to 10 spurious "Missing @context" errors. The wrapper is now checked once instead.

### 3. The placeholder list contained the bare string `"REPLACE"`

Matched case-insensitively against the whole serialized object, so an article headlined "How to Replace a Faucet" was reported as containing placeholder text. `_is_critical()` treats placeholder findings as critical and `main()` exits 2, so ordinary prose could block. Narrowed to the scaffolding forms (`[REPLACE`, `REPLACE_ME`, `REPLACE WITH`), and bracketed placeholders like `[Business Name]` still fire.

### Tests

Adds `tests/test_validate_schema.py`, 17 tests. Nine fail against `main`.

Plugin mirror synced, `check-plugin-sync.py` passes.