### PR TITLE
fix: stamp report provenance; make stock rewrite advice domain-neutral

### DIFF
--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/backlink_analyzer.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/backlink_analyzer.py
@@ -860,7 +860,8 @@ def generate_issues_and_recommendations(
 # ── Full Analysis ────────────────────────────────────────────────────────
 
 def run_analysis(backlinks: list, competitor_backlinks: list = None,
-                 competitor_url: str = "", target_url: str = "") -> dict:
+                 competitor_url: str = "", target_url: str = "",
+                 data_source: str = "unknown") -> dict:
     if not backlinks:
         return {"error": "No backlink data provided.", "issues": [], "recommendations": []}
 
@@ -891,6 +892,12 @@ def run_analysis(backlinks: list, competitor_backlinks: list = None,
 
     report = {
         "target_url": target_url,
+        # Provenance travels with the payload. Previously the only signal that a
+        # report was built from generate_sample_data() went to stderr, so stdout
+        # JSON from the default invocation was indistinguishable from a real
+        # profile once it reached a downstream consumer or a client deliverable.
+        "data_source": data_source,
+        "is_sample_data": data_source == "sample",
         "backlink_health_score": health["score"],
         "health_score_breakdown": health,
         "section_1_profile_overview": overview,
@@ -1111,6 +1118,7 @@ def main():
             print(f"Error reading CSV: {e}", file=sys.stderr)
             sys.exit(1)
         backlinks = normalize_backlinks(raw)
+        resolved_source = "csv"
         print(f"Loaded {len(backlinks)} backlinks from {args.input}", file=sys.stderr)
 
     elif args.source == "gsc":
@@ -1119,8 +1127,12 @@ def main():
         print("Falling back to sample data.", file=sys.stderr)
         target = args.target_url or "https://example.com"
         backlinks = generate_sample_data(target)
+        # --source gsc silently produces sample data today, so the payload must
+        # say sample rather than echo back what was requested.
+        resolved_source = "sample"
 
     else:
+        resolved_source = "sample"
         target = args.target_url or "https://example.com"
         backlinks = generate_sample_data(target)
         print(f"Generated {len(backlinks)} sample backlinks for demo.", file=sys.stderr)
@@ -1141,6 +1153,7 @@ def main():
         competitor_backlinks=competitor_backlinks,
         competitor_url=args.competitor_url,
         target_url=args.target_url,
+        data_source=resolved_source,
     )
 
     if args.json:

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/readability.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/readability.py
@@ -290,9 +290,8 @@ def analyze_readability(text: str) -> dict:
                 "current": "Homepage hero intro block is broad and hard to scan.",
                 "suggested": (
                     "Use a 2-3 sentence hero: who you help, what users can do here, and "
-                    "where to start. Example: \"Learn practical ethical hacking with "
-                    "step-by-step guides. Start with Wi-Fi security, Active Directory, or "
-                    "malware analysis using the tracks below.\""
+                    "where to start. Name the audience and the outcome in the first "
+                    "sentence, then point at the primary entry point."
                 ),
                 "current_word_count": "template",
                 "target_word_count": "40-60 total (split into 2-3 sentences)",
@@ -300,9 +299,8 @@ def analyze_readability(text: str) -> dict:
             {
                 "current": "Section descriptions mix too many topics in one long paragraph.",
                 "suggested": (
-                    "Replace with short blurbs per section (1 sentence each) and add a clear "
-                    "CTA link: \"Start Wi-Fi Security\", \"Explore AD Attack Paths\", "
-                    "\"View Red-Team Cheat Sheets\"."
+                    "Replace with short blurbs per section (1 sentence each), each followed "
+                    "by a CTA link naming the specific action for that section."
                 ),
                 "current_word_count": "template",
                 "target_word_count": "12-20 words per blurb",

--- a/scripts/backlink_analyzer.py
+++ b/scripts/backlink_analyzer.py
@@ -860,7 +860,8 @@ def generate_issues_and_recommendations(
 # ── Full Analysis ────────────────────────────────────────────────────────
 
 def run_analysis(backlinks: list, competitor_backlinks: list = None,
-                 competitor_url: str = "", target_url: str = "") -> dict:
+                 competitor_url: str = "", target_url: str = "",
+                 data_source: str = "unknown") -> dict:
     if not backlinks:
         return {"error": "No backlink data provided.", "issues": [], "recommendations": []}
 
@@ -891,6 +892,12 @@ def run_analysis(backlinks: list, competitor_backlinks: list = None,
 
     report = {
         "target_url": target_url,
+        # Provenance travels with the payload. Previously the only signal that a
+        # report was built from generate_sample_data() went to stderr, so stdout
+        # JSON from the default invocation was indistinguishable from a real
+        # profile once it reached a downstream consumer or a client deliverable.
+        "data_source": data_source,
+        "is_sample_data": data_source == "sample",
         "backlink_health_score": health["score"],
         "health_score_breakdown": health,
         "section_1_profile_overview": overview,
@@ -1111,6 +1118,7 @@ def main():
             print(f"Error reading CSV: {e}", file=sys.stderr)
             sys.exit(1)
         backlinks = normalize_backlinks(raw)
+        resolved_source = "csv"
         print(f"Loaded {len(backlinks)} backlinks from {args.input}", file=sys.stderr)
 
     elif args.source == "gsc":
@@ -1119,8 +1127,12 @@ def main():
         print("Falling back to sample data.", file=sys.stderr)
         target = args.target_url or "https://example.com"
         backlinks = generate_sample_data(target)
+        # --source gsc silently produces sample data today, so the payload must
+        # say sample rather than echo back what was requested.
+        resolved_source = "sample"
 
     else:
+        resolved_source = "sample"
         target = args.target_url or "https://example.com"
         backlinks = generate_sample_data(target)
         print(f"Generated {len(backlinks)} sample backlinks for demo.", file=sys.stderr)
@@ -1141,6 +1153,7 @@ def main():
         competitor_backlinks=competitor_backlinks,
         competitor_url=args.competitor_url,
         target_url=args.target_url,
+        data_source=resolved_source,
     )
 
     if args.json:

--- a/scripts/readability.py
+++ b/scripts/readability.py
@@ -290,9 +290,8 @@ def analyze_readability(text: str) -> dict:
                 "current": "Homepage hero intro block is broad and hard to scan.",
                 "suggested": (
                     "Use a 2-3 sentence hero: who you help, what users can do here, and "
-                    "where to start. Example: \"Learn practical ethical hacking with "
-                    "step-by-step guides. Start with Wi-Fi security, Active Directory, or "
-                    "malware analysis using the tracks below.\""
+                    "where to start. Name the audience and the outcome in the first "
+                    "sentence, then point at the primary entry point."
                 ),
                 "current_word_count": "template",
                 "target_word_count": "40-60 total (split into 2-3 sentences)",
@@ -300,9 +299,8 @@ def analyze_readability(text: str) -> dict:
             {
                 "current": "Section descriptions mix too many topics in one long paragraph.",
                 "suggested": (
-                    "Replace with short blurbs per section (1 sentence each) and add a clear "
-                    "CTA link: \"Start Wi-Fi Security\", \"Explore AD Attack Paths\", "
-                    "\"View Red-Team Cheat Sheets\"."
+                    "Replace with short blurbs per section (1 sentence each), each followed "
+                    "by a CTA link naming the specific action for that section."
                 ),
                 "current_word_count": "template",
                 "target_word_count": "12-20 words per blurb",

--- a/tests/test_report_provenance.py
+++ b/tests/test_report_provenance.py
@@ -1,0 +1,92 @@
+"""A report must say where its numbers came from, and stock advice must be
+domain-neutral.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import backlink_analyzer  # noqa: E402
+import readability  # noqa: E402
+
+
+# --- backlink_analyzer provenance -------------------------------------------
+
+@pytest.fixture
+def sample_report():
+    backlinks = backlink_analyzer.generate_sample_data("https://example.com")
+    return backlink_analyzer.run_analysis(
+        backlinks, target_url="https://example.com", data_source="sample"
+    )
+
+
+def test_sample_report_declares_itself_as_sample(sample_report):
+    assert sample_report["data_source"] == "sample"
+    assert sample_report["is_sample_data"] is True
+
+
+def test_real_source_is_not_flagged_as_sample():
+    backlinks = backlink_analyzer.generate_sample_data("https://example.com")
+    report = backlink_analyzer.run_analysis(
+        backlinks, target_url="https://example.com", data_source="csv"
+    )
+
+    assert report["data_source"] == "csv"
+    assert report["is_sample_data"] is False
+
+
+def test_provenance_survives_json_serialization(sample_report):
+    """stderr warnings do not travel; the payload has to carry it."""
+    import json
+
+    round_tripped = json.loads(json.dumps(sample_report, default=str))
+
+    assert round_tripped["is_sample_data"] is True
+
+
+def test_provenance_defaults_to_unknown_not_to_a_real_source():
+    backlinks = backlink_analyzer.generate_sample_data("https://example.com")
+    report = backlink_analyzer.run_analysis(backlinks, target_url="https://example.com")
+
+    assert report["data_source"] == "unknown"
+    assert report["is_sample_data"] is False
+
+
+# --- readability stock recommendations --------------------------------------
+
+LEAKED_TERMS = [
+    "ethical hacking",
+    "Wi-Fi security",
+    "Active Directory",
+    "malware analysis",
+    "Red-Team",
+    "AD Attack Paths",
+]
+
+
+def _all_recommendation_text():
+    source = os.path.join(
+        os.path.dirname(__file__), "..", "scripts", "readability.py"
+    )
+    with open(source, encoding="utf-8") as fh:
+        return fh.read()
+
+
+@pytest.mark.parametrize("term", LEAKED_TERMS)
+def test_stock_recommendations_are_domain_neutral(term):
+    """These came from one client's site and shipped into every report."""
+    assert term.lower() not in _all_recommendation_text().lower(), (
+        f"{term!r} is a leftover from a specific client's copy and would "
+        f"appear verbatim in an unrelated client's report"
+    )
+
+
+def test_the_fallback_recommendations_still_exist():
+    """Neutralising the copy must not delete the feature."""
+    text = _all_recommendation_text()
+
+    assert "sentence_rewrites" in text
+    assert "who you help" in text


### PR DESCRIPTION
Two small, unrelated changes, both about what ends up in front of a client.

1. backlink_analyzer emits no provenance. --source defaults to "sample", and --source gsc falls back to sample too, so the default invocation produces a complete seven-section report from generate_sample_data(). The only signal was a line on stderr; stdout JSON was indistinguishable from a real profile. run_analysis now takes data_source and the payload carries "data_source" and "is_sample_data". Resolved at the call site from what was ACTUALLY used, so --source gsc reports "sample" rather than echoing the request. No behaviour change and no flag is now required, so existing invocations still work.

2. readability's fallback sentence_rewrites carried one client's copy: the suggested hero text was "Learn practical ethical hacking with step-by-step guides. Start with Wi-Fi security, Active Directory, or malware analysis", and the section blurb suggested "Start Wi-Fi Security" / "Explore AD Attack Paths" / "View Red-Team Cheat Sheets". That branch fires whenever no clean prose sentences are extracted and FRE < 40, which is routine, so it shipped into unrelated clients' reports. Rewritten domain-neutral; the feature is unchanged.

Adds tests/test_report_provenance.py (11 tests), 8 of which fail against main.