### PR TITLE
ci: run the test suite

### DIFF
--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -12,6 +12,8 @@ on:
       - 'evals/**'
       - 'setup-plugin.sh'
       - 'scripts/check-plugin-sync.py'
+      - 'tests/**'
+      - 'requirements.txt'
       - 'RELEASE.md'
       - '.github/workflows/validate-plugin.yml'
   pull_request:
@@ -25,10 +27,31 @@ on:
       - 'evals/**'
       - 'setup-plugin.sh'
       - 'scripts/check-plugin-sync.py'
+      - 'tests/**'
+      - 'requirements.txt'
       - 'RELEASE.md'
       - '.github/workflows/validate-plugin.yml'
 
 jobs:
+  tests:
+    name: Test suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+
+      - name: Run pytest
+        run: python -m pytest tests/ -v
+
   validate-json:
     name: Validate JSON files
     runs-on: ubuntu-latest


### PR DESCRIPTION
`tests/` exists but no workflow executes it. `validate-plugin.yml` validates JSON, checks directories, byte-diffs the plugin mirror, runs `py_compile` for syntax only, and runs the eval fixture matcher, but never invokes pytest. `tests/**` is also absent from the `paths` filter, so editing a test does not start a run.

That means `test_url_safety.py`, which is good work covering decimal and hex IPv4 literals and embedded credentials, has been silently not running.

### Change

- New `tests` job: checkout, `setup-python` 3.11 with pip cache, install `requirements.txt` plus pytest, run `pytest tests/ -v`.
- Add `tests/**` and `requirements.txt` to both `paths` filters.

### Verified

Ran the suite against `main` as it stands: **13 passed**. This goes green on merge rather than immediately red.

Worth merging before the other open PRs, since each of those adds tests and this is what makes them prove their own claims in CI.