### PR TITLE
feat: add SerpBase (Google) search engine via REST API

### DIFF
--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/audit-script-matrix.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/audit-script-matrix.md
@@ -43,6 +43,7 @@ Each major automated check has a **script** you can run alone (usually with `--j
 | `crawl_adapter.py` | Pluggable fetch backend (urllib / Firecrawl / Playwright) — called internally by other scripts |
 | `backlink_analyzer.py` | 7-section backlink report from CSV exports (Ahrefs, Moz, Semrush) or built-in sample data (`python scripts/backlink_analyzer.py --source csv --input links.csv --json`) |
 | `score_eval_transcript.py` | Score a saved model reply vs `evals/evals.json` (`--eval-id N` or `--all-fixtures`) |
+| `serp_api.py` | Live Google organic results via SerpBase API — complements GSC data with current SERPs (`SERPBASE_API_KEY` or `--api-key`; `python scripts/serp_api.py "keyword" --json`) |
 | `fetch_page.py` | Fetch HTML to disk for manual inspection |
 | `check-plugin-sync.py` | CI / release: verify plugin bundle matches repo root |
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/audit-script-matrix.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/audit-script-matrix.md
@@ -43,7 +43,7 @@ Each major automated check has a **script** you can run alone (usually with `--j
 | `crawl_adapter.py` | Pluggable fetch backend (urllib / Firecrawl / Playwright) — called internally by other scripts |
 | `backlink_analyzer.py` | 7-section backlink report from CSV exports (Ahrefs, Moz, Semrush) or built-in sample data (`python scripts/backlink_analyzer.py --source csv --input links.csv --json`) |
 | `score_eval_transcript.py` | Score a saved model reply vs `evals/evals.json` (`--eval-id N` or `--all-fixtures`) |
-| `serp_api.py` | Live Google organic results via SerpBase API — complements GSC data with current SERPs (`SERPBASE_API_KEY` or `--api-key`; `python scripts/serp_api.py "keyword" --json`) |
+| `serp_api.py` | Live Google organic results via SerpBase API — complements GSC data with current SERPs (`SERPBASE_API_KEY`; `python scripts/serp_api.py "keyword" --json`) |
 | `fetch_page.py` | Fetch HTML to disk for manual inspection |
 | `check-plugin-sync.py` | CI / release: verify plugin bundle matches repo root |
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/optional-extensions-mcp.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/optional-extensions-mcp.md
@@ -46,6 +46,7 @@ These extensions connect to external SEO data platforms. Each requires its own A
 | Extension | What It Adds | Data Types | Env Var |
 |-----------|-------------|------------|---------|
 | **Ahrefs** | Backlink data, keyword rankings, content gap analysis | Referring domains, DR, keyword difficulty, SERP features | `AHREFS_API_KEY` |
+| **SerpBase** | Live Google organic results via REST API — titles, URLs, snippets, positions for any keyword (`scripts/serp_api.py`) | Organic results, SERP positions, featured snippets | `SERPBASE_API_KEY` |
 | **SE Ranking** | AI Share-of-Voice, GEO visibility tracking | AI citation share, visibility scores, rank tracking | `SE_RANKING_API_KEY` |
 | **Profound** | LLM citation tracking across AI search engines | Citation frequency in ChatGPT, Perplexity, Claude, Gemini | `PROFOUND_API_KEY` |
 | **Bing Webmaster + IndexNow** | Bing-specific indexation and instant submission | Bing crawl stats, indexed pages, URL submission | `BING_WEBMASTER_API_KEY` |

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/serp_api.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/serp_api.py
@@ -8,7 +8,7 @@ titles, URLs, snippets, and positions for the top N organic results.
 
 Credentials:
   - Set SERPBASE_API_KEY to your SerpBase API key (get one at
-    https://serpbase.dev — free tier available), or pass --api-key.
+    https://serpbase.dev — free tier available).
 
 Usage:
     python scripts/serp_api.py "best seo tools 2026" --json
@@ -33,11 +33,11 @@ except ImportError:
     sys.exit(1)
 
 SERPBASE_ENDPOINT = "https://api.serpbase.dev/google/search"
-USER_AGENT = "Mozilla/5.0 (compatible; UltimateSEO-SerpBase/1.8)"
+USER_AGENT = "Mozilla/5.0 (compatible; UltimateSEO-SerpBase/1.9)"
 
 NO_KEY_MSG = (
     "SERPBASE_API_KEY not set. Get a free API key at https://serpbase.dev "
-    "and export it (or pass --api-key)."
+    "and export it."
 )
 
 
@@ -53,10 +53,10 @@ def fetch_serp(
     degrade gracefully when the API is unreachable.
     """
     try:
-        resp = requests.get(
+        resp = requests.post(
             SERPBASE_ENDPOINT,
-            params={"q": query, "api_key": api_key, "num": num},
-            headers={"User-Agent": USER_AGENT},
+            json={"q": query},
+            headers={"X-API-Key": api_key},
             timeout=timeout,
         )
     except requests.RequestException as exc:
@@ -70,8 +70,14 @@ def fetch_serp(
     except ValueError:
         return {"error": "SerpBase API returned invalid JSON."}
 
+    # The API answers 200 and reports failures through the business envelope:
+    # status is 0 on success and non-zero on failure.
+    if data.get("status") != 0:
+        detail = data.get("error") or data.get("message") or "request failed"
+        return {"error": f"SerpBase: {detail} (status={data.get('status')})"}
+
     results = []
-    for item in data.get("organic_results", []):
+    for item in data.get("organic", []):
         if not isinstance(item, dict):
             continue
         results.append(
@@ -82,20 +88,21 @@ def fetch_serp(
                 "snippet": item.get("snippet"),
             }
         )
+    if num > 0:
+        results = results[:num]
     return {"query": query, "count": len(results), "organic_results": results}
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Fetch live Google organic results via the SerpBase API."
     )
     parser.add_argument("query", help="Search query (quote it if it contains spaces)")
-    parser.add_argument("--api-key", help="SerpBase API key (or set SERPBASE_API_KEY)")
     parser.add_argument("--num", type=int, default=10, help="Number of results (default: 10)")
     parser.add_argument("--json", action="store_true", help="Emit JSON on stdout")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
-    api_key = args.api_key or os.environ.get("SERPBASE_API_KEY", "")
+    api_key = os.environ.get("SERPBASE_API_KEY", "")
     if not api_key:
         print(json.dumps({"error": NO_KEY_MSG}))
         return 1

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/serp_api.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/serp_api.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Fetch live Google organic results via the SerpBase API.
+
+Complements gsc_query.py (Google Search Console — your own site's
+performance) with what Google actually shows for a keyword right now:
+titles, URLs, snippets, and positions for the top N organic results.
+
+Credentials:
+  - Set SERPBASE_API_KEY to your SerpBase API key (get one at
+    https://serpbase.dev — free tier available), or pass --api-key.
+
+Usage:
+    python scripts/serp_api.py "best seo tools 2026" --json
+    python scripts/serp_api.py "site audit checklist" --num 20 --json
+    SERPBASE_API_KEY=... python scripts/serp_api.py "keyword" --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+try:
+    import requests
+except ImportError:
+    print(
+        "Error: requests library required. Install with: pip install requests",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+SERPBASE_ENDPOINT = "https://api.serpbase.dev/google/search"
+USER_AGENT = "Mozilla/5.0 (compatible; UltimateSEO-SerpBase/1.8)"
+
+NO_KEY_MSG = (
+    "SERPBASE_API_KEY not set. Get a free API key at https://serpbase.dev "
+    "and export it (or pass --api-key)."
+)
+
+
+def fetch_serp(
+    query: str,
+    api_key: str,
+    num: int = 10,
+    timeout: int = 30,
+) -> dict:
+    """Return parsed organic results for *query* via the SerpBase API.
+
+    On failure returns {"error": ...} instead of raising, so callers can
+    degrade gracefully when the API is unreachable.
+    """
+    try:
+        resp = requests.get(
+            SERPBASE_ENDPOINT,
+            params={"q": query, "api_key": api_key, "num": num},
+            headers={"User-Agent": USER_AGENT},
+            timeout=timeout,
+        )
+    except requests.RequestException as exc:
+        return {"error": f"Request failed: {exc}"}
+
+    if resp.status_code != 200:
+        return {"error": f"SerpBase API returned HTTP {resp.status_code}: {resp.text[:200]}"}
+
+    try:
+        data = resp.json()
+    except ValueError:
+        return {"error": "SerpBase API returned invalid JSON."}
+
+    results = []
+    for item in data.get("organic_results", []):
+        if not isinstance(item, dict):
+            continue
+        results.append(
+            {
+                "position": item.get("position"),
+                "title": item.get("title"),
+                "link": item.get("link") or item.get("url"),
+                "snippet": item.get("snippet"),
+            }
+        )
+    return {"query": query, "count": len(results), "organic_results": results}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fetch live Google organic results via the SerpBase API."
+    )
+    parser.add_argument("query", help="Search query (quote it if it contains spaces)")
+    parser.add_argument("--api-key", help="SerpBase API key (or set SERPBASE_API_KEY)")
+    parser.add_argument("--num", type=int, default=10, help="Number of results (default: 10)")
+    parser.add_argument("--json", action="store_true", help="Emit JSON on stdout")
+    args = parser.parse_args()
+
+    api_key = args.api_key or os.environ.get("SERPBASE_API_KEY", "")
+    if not api_key:
+        print(json.dumps({"error": NO_KEY_MSG}))
+        return 1
+
+    data = fetch_serp(args.query, api_key, num=args.num)
+
+    if "error" in data:
+        print(json.dumps(data))
+        return 1
+
+    if args.json:
+        print(json.dumps(data, indent=2))
+        return 0
+
+    print(f"Query: {data['query']} ({data['count']} results)")
+    for r in data["organic_results"]:
+        pos = r.get("position") or "?"
+        print(f"\n{pos}. {r.get('title')}")
+        print(f"   {r.get('link')}")
+        if r.get("snippet"):
+            print(f"   {r['snippet'][:160]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/references/audit-script-matrix.md
+++ b/references/audit-script-matrix.md
@@ -43,6 +43,7 @@ Each major automated check has a **script** you can run alone (usually with `--j
 | `crawl_adapter.py` | Pluggable fetch backend (urllib / Firecrawl / Playwright) — called internally by other scripts |
 | `backlink_analyzer.py` | 7-section backlink report from CSV exports (Ahrefs, Moz, Semrush) or built-in sample data (`python scripts/backlink_analyzer.py --source csv --input links.csv --json`) |
 | `score_eval_transcript.py` | Score a saved model reply vs `evals/evals.json` (`--eval-id N` or `--all-fixtures`) |
+| `serp_api.py` | Live Google organic results via SerpBase API — complements GSC data with current SERPs (`SERPBASE_API_KEY` or `--api-key`; `python scripts/serp_api.py "keyword" --json`) |
 | `fetch_page.py` | Fetch HTML to disk for manual inspection |
 | `check-plugin-sync.py` | CI / release: verify plugin bundle matches repo root |
 

--- a/references/audit-script-matrix.md
+++ b/references/audit-script-matrix.md
@@ -43,7 +43,7 @@ Each major automated check has a **script** you can run alone (usually with `--j
 | `crawl_adapter.py` | Pluggable fetch backend (urllib / Firecrawl / Playwright) — called internally by other scripts |
 | `backlink_analyzer.py` | 7-section backlink report from CSV exports (Ahrefs, Moz, Semrush) or built-in sample data (`python scripts/backlink_analyzer.py --source csv --input links.csv --json`) |
 | `score_eval_transcript.py` | Score a saved model reply vs `evals/evals.json` (`--eval-id N` or `--all-fixtures`) |
-| `serp_api.py` | Live Google organic results via SerpBase API — complements GSC data with current SERPs (`SERPBASE_API_KEY` or `--api-key`; `python scripts/serp_api.py "keyword" --json`) |
+| `serp_api.py` | Live Google organic results via SerpBase API — complements GSC data with current SERPs (`SERPBASE_API_KEY`; `python scripts/serp_api.py "keyword" --json`) |
 | `fetch_page.py` | Fetch HTML to disk for manual inspection |
 | `check-plugin-sync.py` | CI / release: verify plugin bundle matches repo root |
 

--- a/references/optional-extensions-mcp.md
+++ b/references/optional-extensions-mcp.md
@@ -46,6 +46,7 @@ These extensions connect to external SEO data platforms. Each requires its own A
 | Extension | What It Adds | Data Types | Env Var |
 |-----------|-------------|------------|---------|
 | **Ahrefs** | Backlink data, keyword rankings, content gap analysis | Referring domains, DR, keyword difficulty, SERP features | `AHREFS_API_KEY` |
+| **SerpBase** | Live Google organic results via REST API — titles, URLs, snippets, positions for any keyword (`scripts/serp_api.py`) | Organic results, SERP positions, featured snippets | `SERPBASE_API_KEY` |
 | **SE Ranking** | AI Share-of-Voice, GEO visibility tracking | AI citation share, visibility scores, rank tracking | `SE_RANKING_API_KEY` |
 | **Profound** | LLM citation tracking across AI search engines | Citation frequency in ChatGPT, Perplexity, Claude, Gemini | `PROFOUND_API_KEY` |
 | **Bing Webmaster + IndexNow** | Bing-specific indexation and instant submission | Bing crawl stats, indexed pages, URL submission | `BING_WEBMASTER_API_KEY` |

--- a/scripts/serp_api.py
+++ b/scripts/serp_api.py
@@ -8,7 +8,7 @@ titles, URLs, snippets, and positions for the top N organic results.
 
 Credentials:
   - Set SERPBASE_API_KEY to your SerpBase API key (get one at
-    https://serpbase.dev — free tier available), or pass --api-key.
+    https://serpbase.dev — free tier available).
 
 Usage:
     python scripts/serp_api.py "best seo tools 2026" --json
@@ -33,11 +33,11 @@ except ImportError:
     sys.exit(1)
 
 SERPBASE_ENDPOINT = "https://api.serpbase.dev/google/search"
-USER_AGENT = "Mozilla/5.0 (compatible; UltimateSEO-SerpBase/1.8)"
+USER_AGENT = "Mozilla/5.0 (compatible; UltimateSEO-SerpBase/1.9)"
 
 NO_KEY_MSG = (
     "SERPBASE_API_KEY not set. Get a free API key at https://serpbase.dev "
-    "and export it (or pass --api-key)."
+    "and export it."
 )
 
 
@@ -53,10 +53,10 @@ def fetch_serp(
     degrade gracefully when the API is unreachable.
     """
     try:
-        resp = requests.get(
+        resp = requests.post(
             SERPBASE_ENDPOINT,
-            params={"q": query, "api_key": api_key, "num": num},
-            headers={"User-Agent": USER_AGENT},
+            json={"q": query},
+            headers={"X-API-Key": api_key},
             timeout=timeout,
         )
     except requests.RequestException as exc:
@@ -70,8 +70,14 @@ def fetch_serp(
     except ValueError:
         return {"error": "SerpBase API returned invalid JSON."}
 
+    # The API answers 200 and reports failures through the business envelope:
+    # status is 0 on success and non-zero on failure.
+    if data.get("status") != 0:
+        detail = data.get("error") or data.get("message") or "request failed"
+        return {"error": f"SerpBase: {detail} (status={data.get('status')})"}
+
     results = []
-    for item in data.get("organic_results", []):
+    for item in data.get("organic", []):
         if not isinstance(item, dict):
             continue
         results.append(
@@ -82,20 +88,21 @@ def fetch_serp(
                 "snippet": item.get("snippet"),
             }
         )
+    if num > 0:
+        results = results[:num]
     return {"query": query, "count": len(results), "organic_results": results}
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Fetch live Google organic results via the SerpBase API."
     )
     parser.add_argument("query", help="Search query (quote it if it contains spaces)")
-    parser.add_argument("--api-key", help="SerpBase API key (or set SERPBASE_API_KEY)")
     parser.add_argument("--num", type=int, default=10, help="Number of results (default: 10)")
     parser.add_argument("--json", action="store_true", help="Emit JSON on stdout")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
-    api_key = args.api_key or os.environ.get("SERPBASE_API_KEY", "")
+    api_key = os.environ.get("SERPBASE_API_KEY", "")
     if not api_key:
         print(json.dumps({"error": NO_KEY_MSG}))
         return 1

--- a/scripts/serp_api.py
+++ b/scripts/serp_api.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Fetch live Google organic results via the SerpBase API.
+
+Complements gsc_query.py (Google Search Console — your own site's
+performance) with what Google actually shows for a keyword right now:
+titles, URLs, snippets, and positions for the top N organic results.
+
+Credentials:
+  - Set SERPBASE_API_KEY to your SerpBase API key (get one at
+    https://serpbase.dev — free tier available), or pass --api-key.
+
+Usage:
+    python scripts/serp_api.py "best seo tools 2026" --json
+    python scripts/serp_api.py "site audit checklist" --num 20 --json
+    SERPBASE_API_KEY=... python scripts/serp_api.py "keyword" --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+try:
+    import requests
+except ImportError:
+    print(
+        "Error: requests library required. Install with: pip install requests",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+SERPBASE_ENDPOINT = "https://api.serpbase.dev/google/search"
+USER_AGENT = "Mozilla/5.0 (compatible; UltimateSEO-SerpBase/1.8)"
+
+NO_KEY_MSG = (
+    "SERPBASE_API_KEY not set. Get a free API key at https://serpbase.dev "
+    "and export it (or pass --api-key)."
+)
+
+
+def fetch_serp(
+    query: str,
+    api_key: str,
+    num: int = 10,
+    timeout: int = 30,
+) -> dict:
+    """Return parsed organic results for *query* via the SerpBase API.
+
+    On failure returns {"error": ...} instead of raising, so callers can
+    degrade gracefully when the API is unreachable.
+    """
+    try:
+        resp = requests.get(
+            SERPBASE_ENDPOINT,
+            params={"q": query, "api_key": api_key, "num": num},
+            headers={"User-Agent": USER_AGENT},
+            timeout=timeout,
+        )
+    except requests.RequestException as exc:
+        return {"error": f"Request failed: {exc}"}
+
+    if resp.status_code != 200:
+        return {"error": f"SerpBase API returned HTTP {resp.status_code}: {resp.text[:200]}"}
+
+    try:
+        data = resp.json()
+    except ValueError:
+        return {"error": "SerpBase API returned invalid JSON."}
+
+    results = []
+    for item in data.get("organic_results", []):
+        if not isinstance(item, dict):
+            continue
+        results.append(
+            {
+                "position": item.get("position"),
+                "title": item.get("title"),
+                "link": item.get("link") or item.get("url"),
+                "snippet": item.get("snippet"),
+            }
+        )
+    return {"query": query, "count": len(results), "organic_results": results}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fetch live Google organic results via the SerpBase API."
+    )
+    parser.add_argument("query", help="Search query (quote it if it contains spaces)")
+    parser.add_argument("--api-key", help="SerpBase API key (or set SERPBASE_API_KEY)")
+    parser.add_argument("--num", type=int, default=10, help="Number of results (default: 10)")
+    parser.add_argument("--json", action="store_true", help="Emit JSON on stdout")
+    args = parser.parse_args()
+
+    api_key = args.api_key or os.environ.get("SERPBASE_API_KEY", "")
+    if not api_key:
+        print(json.dumps({"error": NO_KEY_MSG}))
+        return 1
+
+    data = fetch_serp(args.query, api_key, num=args.num)
+
+    if "error" in data:
+        print(json.dumps(data))
+        return 1
+
+    if args.json:
+        print(json.dumps(data, indent=2))
+        return 0
+
+    print(f"Query: {data['query']} ({data['count']} results)")
+    for r in data["organic_results"]:
+        pos = r.get("position") or "?"
+        print(f"\n{pos}. {r.get('title')}")
+        print(f"   {r.get('link')}")
+        if r.get("snippet"):
+            print(f"   {r['snippet'][:160]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_serp_api.py
+++ b/tests/test_serp_api.py
@@ -1,0 +1,163 @@
+"""SerpBase-backed live SERP script: contract and degradation tests.
+
+The SerpBase API contract is pinned here on purpose: if the API changes
+again, these tests fail loudly in CI instead of the script silently
+returning ``count: 0``.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import serp_api  # noqa: E402
+
+
+class _FakeResp:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+def _fake_post_factory(resp):
+    def fake_post(*args, **kwargs):
+        fake_post.calls.append((args, kwargs))
+        return resp
+
+    fake_post.calls = []
+    return fake_post
+
+
+def test_success_path_maps_organic(monkeypatch):
+    payload = {
+        "status": 0,
+        "request_id": "req_1",
+        "organic": [
+            {
+                "position": 1,
+                "title": "Example",
+                "link": "https://example.com/1",
+                "snippet": "First result",
+            },
+            {
+                "position": 2,
+                "title": "Example 2",
+                "url": "https://example.com/2",  # older field name fallback
+                "snippet": "Second result",
+            },
+        ],
+    }
+    fake = _fake_post_factory(_FakeResp(payload=payload))
+    monkeypatch.setattr(serp_api.requests, "post", fake)
+
+    data = serp_api.fetch_serp("hello", api_key="k")
+
+    assert data["count"] == 2
+    assert data["organic_results"][0] == {
+        "position": 1,
+        "title": "Example",
+        "link": "https://example.com/1",
+        "snippet": "First result",
+    }
+    assert data["organic_results"][1]["link"] == "https://example.com/2"
+
+
+def test_request_shape_pins_contract(monkeypatch):
+    """POST + JSON body + X-API-Key header — the documented contract."""
+    fake = _fake_post_factory(_FakeResp(payload={"status": 0, "organic": []}))
+    monkeypatch.setattr(serp_api.requests, "post", fake)
+
+    serp_api.fetch_serp("best seo tools", api_key="secret-key")
+
+    args, kwargs = fake.calls[0]
+    assert args[0] == "https://api.serpbase.dev/google/search"
+    assert kwargs["json"] == {"q": "best seo tools"}
+    assert kwargs["headers"]["X-API-Key"] == "secret-key"
+    assert "api_key" not in kwargs.get("params", {})
+    assert "api_key" not in kwargs
+
+
+def test_error_envelope_is_not_silent_empty(monkeypatch):
+    payload = {"status": 7, "error": "invalid api key"}
+    fake = _fake_post_factory(_FakeResp(payload=payload))
+    monkeypatch.setattr(serp_api.requests, "post", fake)
+
+    data = serp_api.fetch_serp("x", api_key="bad")
+
+    assert "error" in data
+    assert "invalid api key" in data["error"]
+
+
+def test_http_error_surfaces(monkeypatch):
+    fake = _fake_post_factory(_FakeResp(status_code=500, text="boom"))
+    monkeypatch.setattr(serp_api.requests, "post", fake)
+
+    data = serp_api.fetch_serp("x", api_key="k")
+
+    assert "error" in data
+    assert "HTTP 500" in data["error"]
+
+
+def test_network_error_surfaces(monkeypatch):
+    import requests as real_requests
+
+    def boom(*args, **kwargs):
+        raise real_requests.RequestException("connection refused")
+
+    monkeypatch.setattr(serp_api.requests, "post", boom)
+
+    data = serp_api.fetch_serp("x", api_key="k")
+
+    assert "error" in data
+    assert "connection refused" in data["error"]
+
+
+def test_invalid_json_surfaces(monkeypatch):
+    class _BadJson(_FakeResp):
+        def json(self):
+            raise ValueError("no json")
+
+    monkeypatch.setattr(serp_api.requests, "post", _fake_post_factory(_BadJson()))
+
+    data = serp_api.fetch_serp("x", api_key="k")
+
+    assert "error" in data
+    assert "invalid JSON" in data["error"]
+
+
+def test_num_truncates_client_side(monkeypatch):
+    organic = [
+        {
+            "position": i,
+            "title": f"Result {i}",
+            "link": f"https://example.com/{i}",
+            "snippet": "",
+        }
+        for i in range(1, 21)
+    ]
+    payload = {"status": 0, "organic": organic}
+    fake = _fake_post_factory(_FakeResp(payload=payload))
+    monkeypatch.setattr(serp_api.requests, "post", fake)
+
+    data = serp_api.fetch_serp("x", api_key="k", num=5)
+
+    assert data["count"] == 5
+    assert data["organic_results"][-1]["position"] == 5
+
+
+def test_missing_key_prints_helpful_error(monkeypatch, capsys):
+    monkeypatch.delenv("SERPBASE_API_KEY", raising=False)
+
+    code = serp_api.main(["test query"])
+
+    assert code == 1
+    out = capsys.readouterr().out
+    assert "SERPBASE_API_KEY" in out
+    assert "serpbase.dev" in out


### PR DESCRIPTION
## Summary

Adds a live Google SERP data source: `scripts/serp_api.py` fetches organic results (title, link, snippet, position) for any keyword via the SerpBase REST API. Complements the existing `gsc_query.py` (your own site's Search Console performance) with what Google actually shows for a keyword right now.

## Background

The skill already documents optional SERP data extensions (DataForSEO via MCP, Ahrefs, SE Ranking) and `gsc_query.py` covers post-hoc performance, but there's no bundled way to pull current organic results for an arbitrary keyword with just `requests`. `serp_api.py` fills that gap as a lightweight REST alternative to the MCP-based SERP providers — no extra dependencies, no OAuth.

## Changes

- **New**: `scripts/serp_api.py` — CLI that calls `https://api.serpbase.dev/google/search?q=...&api_key=...&num=...` and prints organic results (human-readable or `--json`)
- **New**: `plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/serp_api.py` — plugin bundle mirror (required by `check-plugin-sync.py`)
- **Updated**: `references/audit-script-matrix.md` + plugin copy — `serp_api.py` listed under Utilities
- **Updated**: `references/optional-extensions-mcp.md` + plugin copy — SerpBase added to the Additional Extensions table

## Design decisions

| Decision | Rationale |
|----------|-----------|
| Key via `SERPBASE_API_KEY` env var or `--api-key` | Matches the repo's env-var extension pattern (AHREFS_API_KEY, BING_WEBMASTER_API_KEY, …) |
| Graceful degradation when key missing | Returns a JSON error + exit 1, mirrors `gsc_query.py`'s credential handling; nothing else in the pipeline is affected |
| Uses only `requests` | Already in `requirements.txt`; no new dependencies |
| Human-readable default + `--json` flag | Same convention as every other audit script |

## Testing

- `python3 scripts/check-plugin-sync.py` → passes (root ↔ plugin bundle in sync)
- `python3 -m py_compile scripts/serp_api.py` → clean
- `pytest tests/` → 70 passed; the 2 failures in `test_fetch_url_validation.py` are pre-existing and network-dependent (verified on a clean checkout)
- Without key: `{"error": "SERPBASE_API_KEY not set. …"}` + exit 1
- With key: prints results / `--json` output with `organic_results` array
