### PR TITLE
chore: gitignore agent tooling storage and local MCP config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,13 @@ article-*.md
 # Claude Code local settings
 .claude/
 
+# AXME Code agent storage (sessions, audit logs, knowledge base) — machine-local,
+# regenerated per session; 681 files / ~3.2 MB at time of writing
+.axme-code/
+
+# Local MCP server wiring — points at binaries installed on this machine
+.mcp.json
+
 # OS files
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
Follow-up to #17 and #18. Both paths below sat untracked in the repo root and appeared in every `git status`, which makes it easy to sweep them into an unrelated commit by accident.

## What changed

Two entries added to `.gitignore`, alongside the existing `.claude/` block since the reasoning is the same:

| Path | Why |
|---|---|
| `.axme-code/` | AXME agent session data, audit logs and knowledge base — 681 files / ~3.2 MB, regenerated per session, machine-specific |
| `.mcp.json` | MCP server wiring pointing at the locally installed `axme-code` binary; not portable to another checkout |

## Reviewer notes

- **No secrets involved.** I checked `.mcp.json` before ignoring it — it contains only `{"mcpServers": {"axme": {"command": "axme-code", "args": ["serve"]}}}`, no keys or tokens. It's ignored for portability, not secrecy. Worth noting because `.gitignore` is the wrong tool for secrets anyway.
- **Neither path was ever tracked**, so this changes nothing already in history — verified with `git ls-files`. No `git rm --cached` needed.
- **Rules verified to match** with `git check-ignore -v`, not just assumed from the pattern.

## Deliberately left alone

`.cursor/rules/*.md` (24 files) stays untracked-but-not-ignored. Those are authored shared agent rules rather than generated state, so whether they belong in the repo is a content decision, not a hygiene one — and `.gitignore` already excludes the single machine-specific file among them (`filesystem-access.mdc`). Ignoring the whole directory would quietly foreclose that choice.

No code, docs, or test changes; `main` stays at v1.11.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)