### PR TITLE
docs: record the .gitignore change under [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **`.gitignore`** — Added `.axme-code/` (AXME agent session data, audit logs and knowledge base — ~681 files regenerated per session) and `.mcp.json` (MCP server wiring pointing at a locally installed binary). Both sat untracked in the repo root and appeared in every `git status`, making accidental inclusion in unrelated commits easy. Neither was ever tracked, so no history is affected. `.cursor/rules/*.md` is deliberately not ignored — those are authored shared agent rules rather than generated state.
+
 ## [1.11.0] - 2026-08-17
 
 ### Added


### PR DESCRIPTION
Follow-up to #19, which changed `.gitignore` without a CHANGELOG entry.

This repo does document `.gitignore` changes — `[1.2.0]` carries *".gitignore — Added `.claude/` to prevent accidental commits of local Claude Code settings."* — so the omission was an inconsistency rather than a deliberate skip.

## Why `[Unreleased]` and not `[1.11.0]`

`v1.11.0` is already tagged and pushed, pointing at `1715979` (the #18 merge). The gitignore commits (`834cb83`, `8306c51`) land **after** that tag. Filing them under `[1.11.0]` would describe a change that tag does not contain — anyone diffing `v1.11.0` against the notes would find the entry unsupported.

**No version bump.** The change affects repo hygiene only, not the shipped plugin, so it rolls into whatever the next release turns out to be.

## Two related observations, not addressed here

Flagging rather than fixing, since both are your call:

1. **`v1.11.0` has a git tag but no GitHub Release.** `gh release list` stops at `v1.10.2`, so the v1.11.0 notes aren't published anywhere user-facing yet.
2. **`CHANGELOG.md` has a `[1.10.3]` section that was never tagged.** 1.10.3 shipped in #17 and was superseded by 1.11.0 in #18 within the same session. The section accurately records what changed, so leaving it is defensible — but if you'd rather the file only list released versions, those entries could fold into `[1.11.0]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)