### PR TITLE
docs: fold the never-tagged 1.10.3 section into 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## [1.11.0] - 2026-08-17
 
+> Supersedes the 1.10.3 version bump, which was raised and then superseded
+> within the same day and never tagged. Its entries are folded in below, so
+> anything referencing 1.10.3 (PR #17, commit messages) is covered here.
+
 ### Added
 
 - **Visible-HTML parity check for FAQ answers** — Flags FAQ answer text that appears in JSON-LD but not in the rendered HTML: the markup satisfies a parser while users and AI crawlers see nothing. A specialisation of `references/procedures/03-geo-ai-search.md` step 4, feeding the Citability dimension of the GEO Score.
@@ -19,7 +23,7 @@
 
 - **`tests/test_schema_status_parity.py`** — Asserts the script-level schema status sets match the tables in `references/schema-types.md`, that the retired and no-rich-results buckets are mutually exclusive, and that all three scripts agree with each other. `check-plugin-sync.py` verifies the two trees are identical but says nothing about whether either is *correct* — a green sync check sat on top of every bug fixed in 1.10.3. Verified by reintroducing each of those bugs in turn; the new test catches all four.
 
-- **Tests** — 27 new tests (117 total, up from 90).
+- **Tests** — 45 new tests; 117 total, up from 72. Of these, 18 regression tests in `tests/test_validate_schema.py` cover the schema status fixes (rich-results-removed types stay `[info]` and never block, `FAQPage` carries no gov/health restriction, `Dataset` never triggers `_is_critical()`, truly retired types still block, and neither bogus practice-problem spelling is flagged) and all 18 fail against the pre-fix code. The remaining 27 cover FAQ visible-HTML parity and doc/code status parity.
 
 ### Changed
 
@@ -30,7 +34,9 @@
 
 - **Schema status sets hoisted to module level** in `validate_schema.py` (`RETIRED_TYPES`, `NO_RICH_RESULTS_TYPES`) and `parse_html.py` (`DEPRECATED_SCHEMA`, `NO_RICH_RESULTS`) so the parity test can import them. Minimal form of the single-source-of-truth refactor; behaviour unchanged.
 
-## [1.10.3] - 2026-08-17
+- **`references/schema-types.md`** — `Practice Problem` and `Dataset` removed from the RETIRED table (both contradicted the rich-results-removed table above it); `Quiz` and `Dataset` rows added to RICH RESULTS REMOVED; `EnergyConsumptionDetails` added to RETIRED. FAQ tooling-sunset phases (search appearance filter, rich result report, and Rich Results Test in June 2026; Search Console API in August 2026) recorded and **explicitly attributed to secondary reporting** — Google deleted the FAQ documentation on June 15, 2026, so only the May 7, 2026 withdrawal is confirmable against Google's own changelog.
+
+- **`AGENTS.md` §19 and `references/procedures/19-quality-gates-hard-rules.md`** — Retired-schema list no longer lists Practice Problem; Dataset and Quiz notes clarified so docs and scripts agree.
 
 ### Fixed
 
@@ -47,16 +53,6 @@
 - **Practice problem schema type corrected to `Quiz`** — `validate_schema.py` used `"PracticeProblem"` and the other two used `"PracticeProblems"`. Neither is a real schema.org type (both 404); the markup behind Google's retired practice-problem feature is `@type: Quiz`, which remains valid under `LearningResource`. Both dead strings never matched real markup. Now keyed on `Quiz` and treated as rich-results-removed, not retired.
 
 - **`EnergyConsumptionDetails` added to the retired sets** — Documented in `AGENTS.md` and `references/schema-types.md` but present in no script. Confirmed retired April 24, 2025, replaced by the `Certification` type.
-
-### Changed
-
-- **`references/schema-types.md`** — `Practice Problem` and `Dataset` removed from the RETIRED table (both contradicted the rich-results-removed table above it); `Quiz` and `Dataset` rows added to RICH RESULTS REMOVED; `EnergyConsumptionDetails` added to RETIRED. FAQ tooling-sunset phases (search appearance filter, rich result report, and Rich Results Test in June 2026; Search Console API in August 2026) recorded and **explicitly attributed to secondary reporting** — Google deleted the FAQ documentation on June 15, 2026, so only the May 7, 2026 withdrawal is confirmable against Google's own changelog.
-
-- **`AGENTS.md` §19 and `references/procedures/19-quality-gates-hard-rules.md`** — Retired-schema list no longer lists Practice Problem; Dataset and Quiz notes clarified so docs and scripts agree.
-
-### Added
-
-- **Tests** — 18 regression tests in `tests/test_validate_schema.py` covering: rich-results-removed types stay `[info]` and never block, `FAQPage` carries no gov/health restriction, `Dataset` never triggers `_is_critical()`, truly retired types still block, and neither bogus practice-problem spelling is flagged. All 18 fail against the pre-fix code.
 
 ## [1.10.2] - 2026-08-12
 


### PR DESCRIPTION
`1.10.3` shipped in #17 and was superseded by `1.11.0` in #18 the same day, so no `v1.10.3` tag was ever cut. The changelog listed a version that does not exist as a release — this folds it into `[1.11.0]`, which is the release that actually contains the work.

## What was done

All **16 entries preserved**, merged into `[1.11.0]`'s `Added` / `Changed` / `Fixed` in Keep a Changelog order, with 1.11.0's own entries leading each subsection. A short note under the heading points anything still referencing 1.10.3 (PR #17, commit messages) at 1.11.0.

## Verification

Checked programmatically rather than by eye, since silent entry loss is the real risk in a fold:

| Check | Result |
|---|---|
| Entries before (1.11.0 + 1.10.3) vs after | 16 → 16 |
| Lost | none |
| Invented | none |
| `[1.10.3]` heading removed | yes; no other version heading changed |
| Every other section byte-identical | yes (`## [1.10.2]` onward compared exactly) |

## One thing the fold surfaced

Both sections had a `**Tests**` entry, and merging them put two in one `### Added` block — with `1.11.0`'s reading *"27 new tests, up from 90."* That 90 was the intermediate count after #17, which no longer appears anywhere in the file once the sections merge, so the sentence became unanchored.

Consolidated into a single entry stated against numbers that still mean something: **45 new tests, 117 total, up from the 72 at the start of the work.** Confirmed by running the suite (`117 passed`; `50 passed` in `test_validate_schema.py`) rather than by adding the old figures together.

The two `**scripts/validate_schema.py**` entries under `### Fixed` are left as-is — they describe two different bugs (the FAQPage restriction and the Dataset retirement) and were already separate entries.

No version bump; no code, test or doc changes outside `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)