### PR TITLE
fix: keep AGENTS.md inside Codex's 32 KiB budget (v1.12.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
     "name": "Myk Pono"
   },
   "metadata": {
-    "version": "1.12.0"
+    "version": "1.12.1"
   },
   "plugins": [
     {
       "name": "ultimate-seo-geo",
       "description": "Scored SEO audits for developers/marketers using AI agents: technical health, JSON-LD, E-E-A-T, backlinks, GEO (AI Overviews, ChatGPT, Perplexity). 46 scripts; HTML/Excel/PDF. E-commerce schema, drift monitoring, topic clustering, Google API tiers, maps intelligence. Optional MCP (Firecrawl, DataForSEO). Parallel workers: agents/PARALLEL-AUDIT.md. Modes: Audit → Plan → Execute.",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "author": {
         "name": "Myk Pono",
         "url": "https://lab.mykpono.com"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.0 |
-| **Updated** | 2026-08-12 |
+| **Version** | 1.12.1 |
+| **Updated** | 2026-08-22 |
 | **License** | MIT |
 | **Author** | Myk Pono |
 | **Homepage** | [lab.mykpono.com](https://lab.mykpono.com) |
@@ -14,32 +14,39 @@ platform that reads `AGENTS.md`. Merges Google's official SEO guidance, 2026 GEO
 and practitioner best practices into one universal framework. Every finding comes with a
 clear fix directive — not just diagnosis.
 
-**Full instructions:** `SKILL.md` is the **routing shell** (§0 + global guardrails + procedure index). Detailed procedures for each § are in `references/procedures/*.md` — read only the file for the section you need. For domain-specific reference data, read the relevant file from `references/` (outside `procedures/`). Load at most **3 files** from `references/` per response (procedure files count toward that limit).
+**Reading budget:** load at most **3 files** from `references/` per response (procedure files count toward that limit). The Routing Index below says which ones.
 
 ## 0. Before You Start
 
 ### Routing Index
 
-| Goal | Read | Run |
-|------|------|-----|
-| Full scored audit | `references/audit-script-matrix.md`, `references/thinking-framework.md` | `generate_report.py` |
-| GEO / AI citations | `references/ai-search-geo.md`, `references/entity-optimization.md` | `robots_checker.py`, `entity_checker.py`, `llms_txt_checker.py` |
-| Schema markup | `references/schema-types.md` | `validate_schema.py` |
-| Technical / CWV | `references/technical-checklist.md` | `pagespeed.py`, `robots_checker.py`, `security_headers.py` |
-| Content / E-E-A-T | `references/eeat-framework.md`, `references/core-eeat-framework.md` | `readability.py`, `article_seo.py` |
-| CITE domain audit | `references/cite-domain-rating.md` | `link_profile.py` |
-| Backlinks | `references/backlink-quality.md` | `backlink_analyzer.py` |
-| Keywords / clusters | `references/keyword-strategy.md` | — |
-| Links | `references/link-building.md` | `internal_links.py`, `broken_links.py`, `link_profile.py` |
-| Local SEO | `references/local-seo.md` | `local_signals_checker.py` |
-| Images | `references/image-seo.md` | `image_checker.py` |
-| International / hreflang | `references/international-seo.md` | `hreflang_checker.py` |
-| Programmatic SEO | `references/programmatic-seo.md` | `programmatic_seo_auditor.py` |
-| Migration | `references/site-migration.md` | `redirect_checker.py` |
-| Analytics / myths | `references/analytics-reporting.md` | — |
-| Crawl / indexation | `references/crawl-indexation.md` | `sitemap_checker.py`, `duplicate_content.py`, `canonical_checker.py` |
-| URL discovery | — | `site_mapper.py` |
-| Extensions | `references/optional-extensions-mcp.md` | Optional MCP (DataForSEO, Firecrawl); monorepo: `extensions/README.md` |
+What to read, what to run, which procedure file has the detail. Full script index:
+`references/audit-script-matrix.md` (45 CLI tools). Routing shell and global guardrails:
+`SKILL.md`.
+
+| Goal | Read | Run | Procedure |
+|------|------|-----|-----------|
+| Full scored audit | `references/audit-script-matrix.md`, `references/thinking-framework.md` | `generate_report.py` | `02-full-site-audit.md` (Mode 3 = execute + verify) |
+| GEO / AI citations | `references/ai-search-geo.md`, `references/entity-optimization.md` | `robots_checker.py`, `entity_checker.py`, `preferred_sources_checker.py` | `03-geo-ai-search.md` |
+| Schema markup | `references/schema-types.md` | `validate_schema.py` | `05-schema-structured-data.md` |
+| Technical / CWV | `references/technical-checklist.md` | `pagespeed.py`, `robots_checker.py`, `security_headers.py` | `04-technical-seo.md` |
+| Content / E-E-A-T | `references/eeat-framework.md`, `references/core-eeat-framework.md` | `readability.py`, `article_seo.py` | `06-content-eeat-and-pruning.md` (§6b = pruning tree) |
+| CITE domain audit | `references/cite-domain-rating.md` | `link_profile.py` | — |
+| Backlinks | `references/backlink-quality.md` | `backlink_analyzer.py` | `09-link-building-internal.md` |
+| Keywords / clusters | `references/keyword-strategy.md` | `topic_cluster.py` | `07-keywords-clusters-aeo.md`, `23-semantic-clustering.md` |
+| Links | `references/link-building.md` | `internal_links.py`, `broken_links.py`, `link_profile.py` | `09-link-building-internal.md` |
+| Local SEO | `references/local-seo.md` | `local_signals_checker.py`, `maps_checker.py` | `12-local-seo.md`, `25-maps-intelligence.md` |
+| Images | `references/image-seo.md` | `image_checker.py` | `13-image-seo.md` |
+| International / hreflang | `references/international-seo.md` | `hreflang_checker.py` | `14-international-hreflang.md` |
+| Programmatic SEO | `references/programmatic-seo.md` | `programmatic_seo_auditor.py` | `15-programmatic-seo.md` |
+| Migration | `references/site-migration.md` | `redirect_checker.py` | `20-site-migration.md` |
+| Analytics / myths | `references/analytics-reporting.md` | `gsc_query.py`, `ga4_report.py`, `gsc_ai_import.py` | `10-analytics-reporting.md`, `18-myths.md` |
+| Crawl / indexation | `references/crawl-indexation.md` | `sitemap_checker.py`, `duplicate_content.py`, `canonical_checker.py` | `11-crawl-indexation.md` (canonical remediation) |
+| Competitor analysis | `references/cite-domain-rating.md` | `link_profile.py` | `08-competitor-analysis.md` |
+| E-commerce | `references/schema-types.md` | `ecommerce_schema.py` | `24-ecommerce-seo.md` |
+| Drift monitoring | — | `drift_monitor.py` | `22-drift-monitoring.md` |
+| URL discovery | — | `site_mapper.py` | — |
+| Extensions | `references/optional-extensions-mcp.md` | Optional MCP (DataForSEO, Firecrawl); monorepo: `extensions/README.md` | — |
 
 ### When NOT to Run a Full Audit
 
@@ -102,6 +109,8 @@ If running on a model with limited context or execution time, apply graceful deg
 ---
 
 ## 1. Request Detection & Routing
+
+Edge cases and ambiguous requests: `references/procedures/01-request-detection-routing.md`.
 
 | Request Type | Trigger Keywords | Go To |
 |---|---|---|
@@ -421,6 +430,8 @@ Script: `programmatic_seo_auditor.py` → `references/programmatic-seo.md`
 
 ## 16. Strategy & Roadmap
 
+Detail: `references/procedures/16-strategy-roadmap.md`.
+
 Triage: `(Business Impact × Ranking Impact) / Effort`. Map dependencies between actions (Blocked By / Unblocks), topologically sort, then group into four phases:
 
 | Phase | Timeframe | Focus |
@@ -434,6 +445,8 @@ Triage: `(Business Impact × Ranking Impact) / Effort`. Map dependencies between
 
 ## 17–18. Maintenance & Myths
 
+Detail: `references/procedures/17-monthly-maintenance.md`, `references/procedures/18-myths.md`.
+
 **Monthly maintenance:** Run through technical health, content & rankings, GEO/AI Search, Local SEO, analytics integrity. Pages losing impressions 3+ months → flag for refresh.
 
 **Myths:** Meta keywords tag is ignored. Word count has no minimum. Core Web Vitals are a tiebreaker not primary factor. E-E-A-T describes quality but is not a direct ranking factor. → `references/analytics-reporting.md`
@@ -441,6 +454,8 @@ Triage: `(Business Impact × Ranking Impact) / Effort`. Map dependencies between
 ---
 
 ## 19. Quality Gates & Hard Rules
+
+Condensed below; full rule text and rationale in `references/procedures/19-quality-gates-hard-rules.md`.
 
 ### Audit Self-Evaluation (run before delivering any audit)
 
@@ -514,93 +529,11 @@ bash scripts/run_individual_checks.sh https://example.com
 
 ### Script Reference
 
-| Script | Purpose |
-|---|---|
-| `generate_report.py` | Full-site HTML/XLSX/PDF dashboard (runs all scripts) |
-| `validate_schema.py` | JSON-LD validation |
-| `robots_checker.py` | robots.txt + AI crawler access |
-| `pagespeed.py` | Core Web Vitals via PageSpeed API |
-| `hreflang_checker.py` | All 8 hreflang rules |
-| `internal_links.py` | Link graph, orphan pages, anchor text |
-| `broken_links.py` | 4xx/5xx broken links + redirect counts |
-| `redirect_checker.py` | Redirect chain analysis |
-| `security_headers.py` | HSTS, CSP, X-Frame-Options |
-| `entity_checker.py` | Wikidata, Wikipedia, sameAs entity signals |
-| `llms_txt_checker.py` | llms.txt presence + format |
-| `indexnow_checker.py` | IndexNow key file validation |
-| `social_meta.py` | Open Graph + Twitter Card |
-| `readability.py` | Flesch-Kincaid grade |
-| `duplicate_content.py` | Near-duplicate detection |
-| `article_seo.py` | Article structure + keyword analysis |
-| `link_profile.py` | Link equity distribution |
-| `backlink_analyzer.py` | 7-section backlink audit (CSV/API data) |
-| `finding_verifier.py` | Deduplicates findings across audit |
-| `sitemap_checker.py` | Sitemap discovery + sanity check |
-| `local_signals_checker.py` | LocalBusiness / tel / address signals |
-| `image_checker.py` | Image alt coverage |
-| `canonical_checker.py` | Canonical tag validation |
-| `meta_lengths_checker.py` | Title / meta description / H1 lengths |
-| `programmatic_seo_auditor.py` | Quality gates for pages at scale |
-| `fetch_page.py` | Fetch and save raw HTML (utility) |
-| `crawl_adapter.py` | Pluggable crawl backend (requests/firecrawl/playwright) |
-| `site_mapper.py` | URL discovery via sitemap + crawl |
-| `drift_monitor.py` | SEO drift baseline, compare, history, report (17 rules) |
-| `topic_cluster.py` | SERP-overlap topic clustering (CSV input) |
-| `content_brief.py` | Content brief generation from competitor analysis |
-| `ecommerce_schema.py` | E-commerce schema validation (Product, Offer, Return, Shipping) |
-| `maps_checker.py` | Advanced local SEO / GBP schema audit |
-| `google_api_tier.py` | Detect available Google API credentials (Tier 0–2) |
-| `crux_history.py` | CrUX History API — historical CWV data (Tier 0) |
-| `gsc_query.py` | Google Search Console queries (Tier 1, OAuth) |
-| `ga4_report.py` | GA4 organic traffic data (Tier 2, OAuth) |
-| `pdf_charts.py` | SVG chart generation for PDF reports (module) |
-| `pdf_template.py` | Professional A4 PDF template with cover + TOC (module) |
+All **45** CLI tools are indexed in `references/audit-script-matrix.md` — audit area, SKILL §,
+script name, and a copy-paste CLI example per row, plus a Utilities table for supporting tools.
+That file is the single source of truth; this section deliberately does not duplicate it.
 
-### Environment Note
-
-Scripts require outbound network access. `pagespeed.py` calls googleapis.com — if it fails, say "performance data unavailable" and use the manual checklist in `references/technical-checklist.md`.
-
-### Excel Export
-
-```bash
-python scripts/generate_report.py https://example.com --format xlsx --output report.xlsx
-python scripts/generate_report.py https://example.com --format all --output report
-```
-
-Requires `openpyxl` (optional): `pip install openpyxl>=3.1.0`
-
-### PDF Export
-
-```bash
-python scripts/generate_report.py https://example.com --format pdf --output report.pdf
-```
-
-Requires **WeasyPrint** (optional): `pip install weasyprint` — see [WeasyPrint installation](https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#installation) for OS libraries. **Fallback:** `--format html` then browser **Print → Save as PDF**.
-
-### Extensions (Optional)
-
-Extensions add external data sources. Core scripts work without them.
-
-| Extension | What It Adds | Install |
-|-----------|-------------|---------|
-| Firecrawl | JS-rendered crawling | `bash extensions/firecrawl/install-generic.sh` |
-| DataForSEO | Live SERP, keywords, backlinks | `bash extensions/dataforseo/install-generic.sh` |
-| Ahrefs | Backlink data, keyword rankings, content gap | MCP config |
-| SE Ranking | AI Share-of-Voice, GEO visibility | MCP config |
-| Profound | LLM citation tracking (ChatGPT, Perplexity, Claude) | MCP config |
-| Bing Webmaster | Bing indexation + IndexNow submission | MCP config |
-
-See `references/optional-extensions-mcp.md` for install paths (plugin bundle); full monorepo: `extensions/README.md`.
-
-### Subagent Definitions
-
-For parallel audit execution, scopes and scripts are in **`agents/PARALLEL-AUDIT.md`** (single file). Each platform interprets these natively — Cursor uses its Task tool, Claude Code can use its Agent tool, others read as context. See `agents/README.md` for the orchestration pattern.
-
-### Context Management for Long Sessions
-
-If context fills mid-audit: compress completed findings into `[Section] Finding | Severity | Fix` one-liners, checkpoint the score, continue with remaining sections, merge back to full format at end.
-
----
+For runnable one-liners grouped by task, see `references/procedures/21-script-toolbox.md`.
 
 ## 22. SEO Drift Monitoring
 
@@ -653,23 +586,3 @@ Script: `maps_checker.py` → `references/procedures/25-maps-intelligence.md`
 Run `google_api_tier.py` to detect available credentials and capabilities. Each tier adds data but lower tiers produce valid audits. See `references/optional-extensions-mcp.md` for extension data sources.
 
 ---
-
-## Full Detail Reference
-
-This file provides enough context to route, audit, and execute. For the routing shell and global guardrails, read `SKILL.md`. For step-by-step procedures, load the matching file from `references/procedures/` (see `references/procedures/README.md`). Key procedures on demand:
-
-| Need | Read |
-|---|---|
-| Full audit process with examples | `references/procedures/02-full-site-audit.md` |
-| GEO citation demonstration pattern | `references/procedures/03-geo-ai-search.md` |
-| Technical audit full checklist | `references/procedures/04-technical-seo.md` |
-| Schema validation checklist | `references/procedures/05-schema-structured-data.md` |
-| Content pruning decision tree | `references/procedures/06-content-eeat-and-pruning.md` (§6b) |
-| Canonical remediation tables | `references/procedures/11-crawl-indexation.md` |
-| Competitor analysis dimensions | `references/procedures/08-competitor-analysis.md` |
-| Migration pre/post checklists | `references/procedures/20-site-migration.md` |
-| Execute + verify loop with examples | `references/procedures/02-full-site-audit.md` (Mode 3) |
-| Drift monitoring rules + workflow | `references/procedures/22-drift-monitoring.md` |
-| SERP-overlap topic clustering | `references/procedures/23-semantic-clustering.md` |
-| E-commerce schema + faceted nav | `references/procedures/24-ecommerce-seo.md` |
-| Geo-grid + GBP + review intelligence | `references/procedures/25-maps-intelligence.md` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,61 @@
 
 _Nothing yet._
 
+## [1.12.1] - 2026-08-22
+
+### Fixed
+
+- **`AGENTS.md` no longer truncates on Codex** — the file was **37,238 bytes** against Codex's
+  32 KiB `project_doc_max_bytes` default. Codex truncates **silently**: no warning in the TUI,
+  `/stats`, `exec`, or the VS Code extension, and everything past the cutoff is never sent to the
+  model. Since the README advertises AGENTS.md compatibility, this was a correctness bug, not
+  housekeeping. Five sections were invisible to every Codex user:
+  §22 Drift Monitoring, §23 Semantic Clustering, §24 E-commerce, §25 Maps Intelligence, and the
+  Google API Tier System — plus **the "Full Detail Reference" table**, the map to `references/`,
+  so the agent could not find the files it was being told to read. Now **32,726 bytes** with
+  nothing truncated.
+
+- **12 CLI tools were missing from `references/audit-script-matrix.md`** — `content_quality.py`,
+  `gsc_export.py` and `render_page.py` appeared in **no** index at all; the other nine
+  (`content_brief`, `crux_history`, `drift_monitor`, `ecommerce_schema`, `ga4_report`,
+  `google_api_tier`, `gsc_query`, `maps_checker`, `topic_cluster`) were listed only in the
+  AGENTS.md section that truncates. The matrix now indexes **all 45** CLI tools and is the single
+  source of truth; `render_page.py` and `google_api_tier.py` were added to the Utilities table.
+
+- **Four procedure files were unreachable from `AGENTS.md`** — `01-request-detection-routing.md`,
+  `16-strategy-roadmap.md`, `17-monthly-maintenance.md` and `19-quality-gates-hard-rules.md` had no
+  pointer, so the agent had no route to them. All **25** are now referenced, with none broken.
+
+- **README version badge and Layer 1 size** — badge tracked 1.10.2 through two releases; the
+  architecture note claimed `AGENTS.md (~27KB)` when it was 37 KB.
+
+### Changed
+
+- **`AGENTS.md` §21 Script Toolbox** — the 39-row inventory table (the file's largest section at
+  5,119 bytes) is replaced with a pointer to `references/audit-script-matrix.md`. The operating
+  rule and the three runnable commands stay inline. Content was **moved, not deleted** — the matrix
+  now covers more scripts than the table ever did.
+
+- **Routing Index and Full Detail Reference merged into one table** — two adjacent tables both
+  mapping need→file became a single `Goal | Read | Run | Procedure` table, and it now sits at byte
+  853 instead of 35,781. This is the structural half of the fix: everything else in `AGENTS.md` is
+  recoverable by reading a reference file, but only while the agent can still see the table telling
+  it which file to read.
+
+- **README documents Codex's instruction budget** — `project_doc_max_bytes` is a **combined** cap
+  across every instruction file Codex loads in the hierarchy, not this file alone, so a user with
+  their own root `AGENTS.md` spends the same budget. No amount of self-trimming can guarantee fit;
+  the README now says so and gives the `~/.codex/config.toml` override, plus the symptom to watch
+  for (Codex acting unaware of §§22–25).
+
+### Added
+
+- **`tests/test_agents_md_size.py`** — four guards, in both trees: the file fits the 32 KiB cap;
+  headroom under 512 bytes `xfail`s rather than passing silently (it is currently 42 bytes — known,
+  accepted, and documented); the Routing Index stays within the first 4 KB; and every procedure
+  file on disk is reachable from `AGENTS.md` with no broken pointers. Validated by reintroducing
+  each failure mode in turn and confirming all three are caught.
+
 ## [1.12.0] - 2026-08-22
 
 Refresh of the Google-facing guidance against everything Google shipped between the last content

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![AGENTS.md](https://img.shields.io/badge/AGENTS.md-compatible-blue)](https://agents.md)
-[![Version](https://img.shields.io/badge/version-1.12.0-green.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.12.1-green.svg)](CHANGELOG.md)
 [![LLM-Agnostic](https://img.shields.io/badge/LLM--Agnostic-7%2B%20platforms-purple.svg)](#platform-compatibility)
 
 The definitive SEO and Generative Engine Optimization agent for AI coding tools. LLM-agnostic — works on any platform that reads `AGENTS.md`. Runs full site audits with scored findings, generates ready-to-deploy fixes, and optimizes content for both Google Search and AI search engines (Google AI Overviews, AI Mode, ChatGPT Search, Perplexity). Exports HTML, Excel, and PDF reports.
@@ -80,6 +80,22 @@ Built for **developers, founders, and marketers using AI coding agents** who wan
 | **Claude Desktop (claude.ai)** | Upload `SKILL.md` to Project Knowledge | No shell access | Manual upload |
 
 `AGENTS.md` is the [cross-tool standard](https://agents.md) (Linux Foundation, 20+ tools). One file covers all AGENTS.md-compatible platforms.
+
+> **Codex users — instruction budget.** Codex loads instruction files up to `project_doc_max_bytes`
+> (**32 KiB** by default) and **truncates silently** past that point: no warning in the TUI, `/stats`,
+> `exec`, or the VS Code extension, and everything after the cutoff is never sent to the model.
+>
+> That budget is **combined across every instruction file Codex loads in the directory hierarchy** —
+> this repo's `AGENTS.md` *plus* any `AGENTS.md` of your own further up the tree. `AGENTS.md` here is
+> kept under the default on its own, and a test (`tests/test_agents_md_size.py`) enforces it, but if
+> you also carry your own instruction files you may still hit the cap. Raise it in `~/.codex/config.toml`:
+>
+> ```toml
+> project_doc_max_bytes = 65536
+> ```
+>
+> Symptom to watch for: Codex behaving as though it has never heard of §§22–25 (drift monitoring,
+> semantic clustering, e-commerce, maps) — those sit at the end of the file and truncate first.
 
 ## Installation
 
@@ -239,7 +255,7 @@ ultimate-seo-geo/
 ```
 
 **Progressive disclosure for cross-platform support:**
-- **Layer 1** — `AGENTS.md` (~27KB): auto-loaded by AGENTS.md-compatible tools. Routing, condensed procedures, script reference, quality gates.
+- **Layer 1** — `AGENTS.md` (~32KB, held under Codex's 32 KiB default): auto-loaded by AGENTS.md-compatible tools. Routing index, condensed procedures, quality gates. The full script index lives in `references/audit-script-matrix.md`.
 - **Layer 2** — `SKILL.md` (routing shell) + `references/procedures/*.md` (detailed steps per §, now §1–§25) + topical `references/*.md` + `scripts/`: load only what the task needs.
 
 For Claude Code and Cursor, `SKILL.md` is loaded natively as a skill (small shell); hosts pull `references/procedures/` when a section’s detail is required. Other platforms use `AGENTS.md` plus explicit reads of procedure files as needed.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ultimate-seo-geo
 description: Audits and optimizes websites for search engine visibility (SEO) and AI search citation (GEO), covering technical health, E-E-A-T content scoring, domain authority, structured data, rich results, and entity signals. Use when running SEO audits, diagnosing traffic drops or ranking losses, generating Schema.org JSON-LD, checking Core Web Vitals, crawlability, robots.txt, sitemaps, hreflang, backlinks, planning content strategy or site migrations, fixing indexing issues, or optimizing for AI Overviews, ChatGPT, and Perplexity. NOT for paid ads (PPC/SEM), social media strategy, email marketing, or general web development unrelated to search.
-version: 1.12.0
+version: 1.12.1
 ---
 
 # Ultimate SEO + GEO — LLM-Agnostic SEO Agent
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.0 |
+| **Version** | 1.12.1 |
 | **Updated** | 2026-08-12 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/plugins/ultimate-seo-geo/.claude-plugin/plugin.json
+++ b/plugins/ultimate-seo-geo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ultimate-seo-geo",
   "description": "Scored SEO audits for developers and marketers using AI agents: technical health, Schema.org JSON-LD, E-E-A-T, backlinks, domain signals, GEO (AI Overviews, ChatGPT, Perplexity). 46 bundled scripts; HTML/Excel/PDF reports. E-commerce schema, drift monitoring, topic clustering, Google API tiers (GSC/GA4), maps intelligence. Optional MCP (Firecrawl, DataForSEO): references/optional-extensions-mcp.md. Modes: Audit → Plan → Execute.",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "author": {
     "name": "Myk Pono",
     "url": "https://lab.mykpono.com"

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
@@ -2,8 +2,8 @@
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.0 |
-| **Updated** | 2026-08-12 |
+| **Version** | 1.12.1 |
+| **Updated** | 2026-08-22 |
 | **License** | MIT |
 | **Author** | Myk Pono |
 | **Homepage** | [lab.mykpono.com](https://lab.mykpono.com) |
@@ -14,32 +14,39 @@ platform that reads `AGENTS.md`. Merges Google's official SEO guidance, 2026 GEO
 and practitioner best practices into one universal framework. Every finding comes with a
 clear fix directive — not just diagnosis.
 
-**Full instructions:** `SKILL.md` is the **routing shell** (§0 + global guardrails + procedure index). Detailed procedures for each § are in `references/procedures/*.md` — read only the file for the section you need. For domain-specific reference data, read the relevant file from `references/` (outside `procedures/`). Load at most **3 files** from `references/` per response (procedure files count toward that limit).
+**Reading budget:** load at most **3 files** from `references/` per response (procedure files count toward that limit). The Routing Index below says which ones.
 
 ## 0. Before You Start
 
 ### Routing Index
 
-| Goal | Read | Run |
-|------|------|-----|
-| Full scored audit | `references/audit-script-matrix.md`, `references/thinking-framework.md` | `generate_report.py` |
-| GEO / AI citations | `references/ai-search-geo.md`, `references/entity-optimization.md` | `robots_checker.py`, `entity_checker.py`, `llms_txt_checker.py` |
-| Schema markup | `references/schema-types.md` | `validate_schema.py` |
-| Technical / CWV | `references/technical-checklist.md` | `pagespeed.py`, `robots_checker.py`, `security_headers.py` |
-| Content / E-E-A-T | `references/eeat-framework.md`, `references/core-eeat-framework.md` | `readability.py`, `article_seo.py` |
-| CITE domain audit | `references/cite-domain-rating.md` | `link_profile.py` |
-| Backlinks | `references/backlink-quality.md` | `backlink_analyzer.py` |
-| Keywords / clusters | `references/keyword-strategy.md` | — |
-| Links | `references/link-building.md` | `internal_links.py`, `broken_links.py`, `link_profile.py` |
-| Local SEO | `references/local-seo.md` | `local_signals_checker.py` |
-| Images | `references/image-seo.md` | `image_checker.py` |
-| International / hreflang | `references/international-seo.md` | `hreflang_checker.py` |
-| Programmatic SEO | `references/programmatic-seo.md` | `programmatic_seo_auditor.py` |
-| Migration | `references/site-migration.md` | `redirect_checker.py` |
-| Analytics / myths | `references/analytics-reporting.md` | — |
-| Crawl / indexation | `references/crawl-indexation.md` | `sitemap_checker.py`, `duplicate_content.py`, `canonical_checker.py` |
-| URL discovery | — | `site_mapper.py` |
-| Extensions | `references/optional-extensions-mcp.md` | Optional MCP (DataForSEO, Firecrawl); monorepo: `extensions/README.md` |
+What to read, what to run, which procedure file has the detail. Full script index:
+`references/audit-script-matrix.md` (45 CLI tools). Routing shell and global guardrails:
+`SKILL.md`.
+
+| Goal | Read | Run | Procedure |
+|------|------|-----|-----------|
+| Full scored audit | `references/audit-script-matrix.md`, `references/thinking-framework.md` | `generate_report.py` | `02-full-site-audit.md` (Mode 3 = execute + verify) |
+| GEO / AI citations | `references/ai-search-geo.md`, `references/entity-optimization.md` | `robots_checker.py`, `entity_checker.py`, `preferred_sources_checker.py` | `03-geo-ai-search.md` |
+| Schema markup | `references/schema-types.md` | `validate_schema.py` | `05-schema-structured-data.md` |
+| Technical / CWV | `references/technical-checklist.md` | `pagespeed.py`, `robots_checker.py`, `security_headers.py` | `04-technical-seo.md` |
+| Content / E-E-A-T | `references/eeat-framework.md`, `references/core-eeat-framework.md` | `readability.py`, `article_seo.py` | `06-content-eeat-and-pruning.md` (§6b = pruning tree) |
+| CITE domain audit | `references/cite-domain-rating.md` | `link_profile.py` | — |
+| Backlinks | `references/backlink-quality.md` | `backlink_analyzer.py` | `09-link-building-internal.md` |
+| Keywords / clusters | `references/keyword-strategy.md` | `topic_cluster.py` | `07-keywords-clusters-aeo.md`, `23-semantic-clustering.md` |
+| Links | `references/link-building.md` | `internal_links.py`, `broken_links.py`, `link_profile.py` | `09-link-building-internal.md` |
+| Local SEO | `references/local-seo.md` | `local_signals_checker.py`, `maps_checker.py` | `12-local-seo.md`, `25-maps-intelligence.md` |
+| Images | `references/image-seo.md` | `image_checker.py` | `13-image-seo.md` |
+| International / hreflang | `references/international-seo.md` | `hreflang_checker.py` | `14-international-hreflang.md` |
+| Programmatic SEO | `references/programmatic-seo.md` | `programmatic_seo_auditor.py` | `15-programmatic-seo.md` |
+| Migration | `references/site-migration.md` | `redirect_checker.py` | `20-site-migration.md` |
+| Analytics / myths | `references/analytics-reporting.md` | `gsc_query.py`, `ga4_report.py`, `gsc_ai_import.py` | `10-analytics-reporting.md`, `18-myths.md` |
+| Crawl / indexation | `references/crawl-indexation.md` | `sitemap_checker.py`, `duplicate_content.py`, `canonical_checker.py` | `11-crawl-indexation.md` (canonical remediation) |
+| Competitor analysis | `references/cite-domain-rating.md` | `link_profile.py` | `08-competitor-analysis.md` |
+| E-commerce | `references/schema-types.md` | `ecommerce_schema.py` | `24-ecommerce-seo.md` |
+| Drift monitoring | — | `drift_monitor.py` | `22-drift-monitoring.md` |
+| URL discovery | — | `site_mapper.py` | — |
+| Extensions | `references/optional-extensions-mcp.md` | Optional MCP (DataForSEO, Firecrawl); monorepo: `extensions/README.md` | — |
 
 ### When NOT to Run a Full Audit
 
@@ -102,6 +109,8 @@ If running on a model with limited context or execution time, apply graceful deg
 ---
 
 ## 1. Request Detection & Routing
+
+Edge cases and ambiguous requests: `references/procedures/01-request-detection-routing.md`.
 
 | Request Type | Trigger Keywords | Go To |
 |---|---|---|
@@ -421,6 +430,8 @@ Script: `programmatic_seo_auditor.py` → `references/programmatic-seo.md`
 
 ## 16. Strategy & Roadmap
 
+Detail: `references/procedures/16-strategy-roadmap.md`.
+
 Triage: `(Business Impact × Ranking Impact) / Effort`. Map dependencies between actions (Blocked By / Unblocks), topologically sort, then group into four phases:
 
 | Phase | Timeframe | Focus |
@@ -434,6 +445,8 @@ Triage: `(Business Impact × Ranking Impact) / Effort`. Map dependencies between
 
 ## 17–18. Maintenance & Myths
 
+Detail: `references/procedures/17-monthly-maintenance.md`, `references/procedures/18-myths.md`.
+
 **Monthly maintenance:** Run through technical health, content & rankings, GEO/AI Search, Local SEO, analytics integrity. Pages losing impressions 3+ months → flag for refresh.
 
 **Myths:** Meta keywords tag is ignored. Word count has no minimum. Core Web Vitals are a tiebreaker not primary factor. E-E-A-T describes quality but is not a direct ranking factor. → `references/analytics-reporting.md`
@@ -441,6 +454,8 @@ Triage: `(Business Impact × Ranking Impact) / Effort`. Map dependencies between
 ---
 
 ## 19. Quality Gates & Hard Rules
+
+Condensed below; full rule text and rationale in `references/procedures/19-quality-gates-hard-rules.md`.
 
 ### Audit Self-Evaluation (run before delivering any audit)
 
@@ -514,93 +529,11 @@ bash scripts/run_individual_checks.sh https://example.com
 
 ### Script Reference
 
-| Script | Purpose |
-|---|---|
-| `generate_report.py` | Full-site HTML/XLSX/PDF dashboard (runs all scripts) |
-| `validate_schema.py` | JSON-LD validation |
-| `robots_checker.py` | robots.txt + AI crawler access |
-| `pagespeed.py` | Core Web Vitals via PageSpeed API |
-| `hreflang_checker.py` | All 8 hreflang rules |
-| `internal_links.py` | Link graph, orphan pages, anchor text |
-| `broken_links.py` | 4xx/5xx broken links + redirect counts |
-| `redirect_checker.py` | Redirect chain analysis |
-| `security_headers.py` | HSTS, CSP, X-Frame-Options |
-| `entity_checker.py` | Wikidata, Wikipedia, sameAs entity signals |
-| `llms_txt_checker.py` | llms.txt presence + format |
-| `indexnow_checker.py` | IndexNow key file validation |
-| `social_meta.py` | Open Graph + Twitter Card |
-| `readability.py` | Flesch-Kincaid grade |
-| `duplicate_content.py` | Near-duplicate detection |
-| `article_seo.py` | Article structure + keyword analysis |
-| `link_profile.py` | Link equity distribution |
-| `backlink_analyzer.py` | 7-section backlink audit (CSV/API data) |
-| `finding_verifier.py` | Deduplicates findings across audit |
-| `sitemap_checker.py` | Sitemap discovery + sanity check |
-| `local_signals_checker.py` | LocalBusiness / tel / address signals |
-| `image_checker.py` | Image alt coverage |
-| `canonical_checker.py` | Canonical tag validation |
-| `meta_lengths_checker.py` | Title / meta description / H1 lengths |
-| `programmatic_seo_auditor.py` | Quality gates for pages at scale |
-| `fetch_page.py` | Fetch and save raw HTML (utility) |
-| `crawl_adapter.py` | Pluggable crawl backend (requests/firecrawl/playwright) |
-| `site_mapper.py` | URL discovery via sitemap + crawl |
-| `drift_monitor.py` | SEO drift baseline, compare, history, report (17 rules) |
-| `topic_cluster.py` | SERP-overlap topic clustering (CSV input) |
-| `content_brief.py` | Content brief generation from competitor analysis |
-| `ecommerce_schema.py` | E-commerce schema validation (Product, Offer, Return, Shipping) |
-| `maps_checker.py` | Advanced local SEO / GBP schema audit |
-| `google_api_tier.py` | Detect available Google API credentials (Tier 0–2) |
-| `crux_history.py` | CrUX History API — historical CWV data (Tier 0) |
-| `gsc_query.py` | Google Search Console queries (Tier 1, OAuth) |
-| `ga4_report.py` | GA4 organic traffic data (Tier 2, OAuth) |
-| `pdf_charts.py` | SVG chart generation for PDF reports (module) |
-| `pdf_template.py` | Professional A4 PDF template with cover + TOC (module) |
+All **45** CLI tools are indexed in `references/audit-script-matrix.md` — audit area, SKILL §,
+script name, and a copy-paste CLI example per row, plus a Utilities table for supporting tools.
+That file is the single source of truth; this section deliberately does not duplicate it.
 
-### Environment Note
-
-Scripts require outbound network access. `pagespeed.py` calls googleapis.com — if it fails, say "performance data unavailable" and use the manual checklist in `references/technical-checklist.md`.
-
-### Excel Export
-
-```bash
-python scripts/generate_report.py https://example.com --format xlsx --output report.xlsx
-python scripts/generate_report.py https://example.com --format all --output report
-```
-
-Requires `openpyxl` (optional): `pip install openpyxl>=3.1.0`
-
-### PDF Export
-
-```bash
-python scripts/generate_report.py https://example.com --format pdf --output report.pdf
-```
-
-Requires **WeasyPrint** (optional): `pip install weasyprint` — see [WeasyPrint installation](https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#installation) for OS libraries. **Fallback:** `--format html` then browser **Print → Save as PDF**.
-
-### Extensions (Optional)
-
-Extensions add external data sources. Core scripts work without them.
-
-| Extension | What It Adds | Install |
-|-----------|-------------|---------|
-| Firecrawl | JS-rendered crawling | `bash extensions/firecrawl/install-generic.sh` |
-| DataForSEO | Live SERP, keywords, backlinks | `bash extensions/dataforseo/install-generic.sh` |
-| Ahrefs | Backlink data, keyword rankings, content gap | MCP config |
-| SE Ranking | AI Share-of-Voice, GEO visibility | MCP config |
-| Profound | LLM citation tracking (ChatGPT, Perplexity, Claude) | MCP config |
-| Bing Webmaster | Bing indexation + IndexNow submission | MCP config |
-
-See `references/optional-extensions-mcp.md` for install paths (plugin bundle); full monorepo: `extensions/README.md`.
-
-### Subagent Definitions
-
-For parallel audit execution, scopes and scripts are in **`agents/PARALLEL-AUDIT.md`** (single file). Each platform interprets these natively — Cursor uses its Task tool, Claude Code can use its Agent tool, others read as context. See `agents/README.md` for the orchestration pattern.
-
-### Context Management for Long Sessions
-
-If context fills mid-audit: compress completed findings into `[Section] Finding | Severity | Fix` one-liners, checkpoint the score, continue with remaining sections, merge back to full format at end.
-
----
+For runnable one-liners grouped by task, see `references/procedures/21-script-toolbox.md`.
 
 ## 22. SEO Drift Monitoring
 
@@ -653,23 +586,3 @@ Script: `maps_checker.py` → `references/procedures/25-maps-intelligence.md`
 Run `google_api_tier.py` to detect available credentials and capabilities. Each tier adds data but lower tiers produce valid audits. See `references/optional-extensions-mcp.md` for extension data sources.
 
 ---
-
-## Full Detail Reference
-
-This file provides enough context to route, audit, and execute. For the routing shell and global guardrails, read `SKILL.md`. For step-by-step procedures, load the matching file from `references/procedures/` (see `references/procedures/README.md`). Key procedures on demand:
-
-| Need | Read |
-|---|---|
-| Full audit process with examples | `references/procedures/02-full-site-audit.md` |
-| GEO citation demonstration pattern | `references/procedures/03-geo-ai-search.md` |
-| Technical audit full checklist | `references/procedures/04-technical-seo.md` |
-| Schema validation checklist | `references/procedures/05-schema-structured-data.md` |
-| Content pruning decision tree | `references/procedures/06-content-eeat-and-pruning.md` (§6b) |
-| Canonical remediation tables | `references/procedures/11-crawl-indexation.md` |
-| Competitor analysis dimensions | `references/procedures/08-competitor-analysis.md` |
-| Migration pre/post checklists | `references/procedures/20-site-migration.md` |
-| Execute + verify loop with examples | `references/procedures/02-full-site-audit.md` (Mode 3) |
-| Drift monitoring rules + workflow | `references/procedures/22-drift-monitoring.md` |
-| SERP-overlap topic clustering | `references/procedures/23-semantic-clustering.md` |
-| E-commerce schema + faceted nav | `references/procedures/24-ecommerce-seo.md` |
-| Geo-grid + GBP + review intelligence | `references/procedures/25-maps-intelligence.md` |

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/SKILL.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ultimate-seo-geo
 description: Audits and optimizes websites for search engine visibility (SEO) and AI search citation (GEO), covering technical health, E-E-A-T content scoring, domain authority, structured data, rich results, and entity signals. Use when running SEO audits, diagnosing traffic drops or ranking losses, generating Schema.org JSON-LD, checking Core Web Vitals, crawlability, robots.txt, sitemaps, hreflang, backlinks, planning content strategy or site migrations, fixing indexing issues, or optimizing for AI Overviews, ChatGPT, and Perplexity. NOT for paid ads (PPC/SEM), social media strategy, email marketing, or general web development unrelated to search.
-version: 1.12.0
+version: 1.12.1
 ---
 
 # Ultimate SEO + GEO — LLM-Agnostic SEO Agent
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.0 |
+| **Version** | 1.12.1 |
 | **Updated** | 2026-08-12 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/audit-script-matrix.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/audit-script-matrix.md
@@ -34,6 +34,17 @@ Each major automated check has a **script** you can run alone (usually with `--j
 | JSON-LD validation | §5 | `validate_schema.py` | `python scripts/validate_schema.py file.html --json` |
 | Image alt coverage | §13 | `image_checker.py` | `python scripts/image_checker.py page.html --base-url URL --json` |
 | Programmatic SEO audit | §15 | `programmatic_seo_auditor.py` | `python scripts/programmatic_seo_auditor.py URL --depth 2 --max-pages 100 --json` |
+| Content quality signals | §6 | `content_quality.py` | `python scripts/content_quality.py URL --json` |
+| Content brief generation | §7 | `content_brief.py` | `python scripts/content_brief.py "target keyword" --json` |
+| Topic clustering (SERP overlap) | §23 | `topic_cluster.py` | `python scripts/topic_cluster.py --input serp_data.csv --format serp_overlap --json` |
+| E-commerce schema (Product/Offer) | §24 | `ecommerce_schema.py` | `python scripts/ecommerce_schema.py URL --json` |
+| Maps / GBP intelligence | §25 | `maps_checker.py` | `python scripts/maps_checker.py URL --json` |
+| Core Web Vitals history (CrUX) | §4 | `crux_history.py` | `python scripts/crux_history.py URL --metric lcp --json` |
+| SEO drift baseline / compare | §22 | `drift_monitor.py` | `python scripts/drift_monitor.py baseline URL` then `compare URL` |
+| GSC performance query (Tier 1) | §10 | `gsc_query.py` | `python scripts/gsc_query.py --property SITE --dimension page --json` |
+| GSC URL inspection export (Tier 1) | §10 | `gsc_export.py` | `python scripts/gsc_export.py --property SITE --sitemap-url URL` |
+| GSC generative-AI impressions (manual CSV) | §10 | `gsc_ai_import.py` | `python scripts/gsc_ai_import.py export.csv --json` |
+| GA4 organic reporting (Tier 1) | §10 | `ga4_report.py` | `python scripts/ga4_report.py --property 123456789 --organic-only --json` |
 | Finding deduplication | §2 | `finding_verifier.py` | `python scripts/finding_verifier.py --findings-json references/finding-verifier-example.json --json` (see `references/finding-verifier-context-example.json` for optional `--context-json`) |
 
 ## Utilities (supporting tools)
@@ -46,6 +57,8 @@ Each major automated check has a **script** you can run alone (usually with `--j
 | `backlink_analyzer.py` | 7-section backlink report from CSV exports (Ahrefs, Moz, Semrush) or built-in sample data (`python scripts/backlink_analyzer.py --source csv --input links.csv --json`) |
 | `score_eval_transcript.py` | Score a saved model reply vs `evals/evals.json` (`--eval-id N` or `--all-fixtures`) |
 | `fetch_page.py` | Fetch HTML to disk for manual inspection |
+| `render_page.py` | Render a page with Playwright (JS-heavy sites) so client-rendered content is visible to the other checkers |
+| `google_api_tier.py` | Report which Google API tier is available from configured credentials (`python scripts/google_api_tier.py --check`) |
 | `check-plugin-sync.py` | CI / release: verify plugin bundle matches repo root |
 
 ## Reference-only areas (no dedicated `.py` checker)

--- a/references/audit-script-matrix.md
+++ b/references/audit-script-matrix.md
@@ -34,6 +34,17 @@ Each major automated check has a **script** you can run alone (usually with `--j
 | JSON-LD validation | §5 | `validate_schema.py` | `python scripts/validate_schema.py file.html --json` |
 | Image alt coverage | §13 | `image_checker.py` | `python scripts/image_checker.py page.html --base-url URL --json` |
 | Programmatic SEO audit | §15 | `programmatic_seo_auditor.py` | `python scripts/programmatic_seo_auditor.py URL --depth 2 --max-pages 100 --json` |
+| Content quality signals | §6 | `content_quality.py` | `python scripts/content_quality.py URL --json` |
+| Content brief generation | §7 | `content_brief.py` | `python scripts/content_brief.py "target keyword" --json` |
+| Topic clustering (SERP overlap) | §23 | `topic_cluster.py` | `python scripts/topic_cluster.py --input serp_data.csv --format serp_overlap --json` |
+| E-commerce schema (Product/Offer) | §24 | `ecommerce_schema.py` | `python scripts/ecommerce_schema.py URL --json` |
+| Maps / GBP intelligence | §25 | `maps_checker.py` | `python scripts/maps_checker.py URL --json` |
+| Core Web Vitals history (CrUX) | §4 | `crux_history.py` | `python scripts/crux_history.py URL --metric lcp --json` |
+| SEO drift baseline / compare | §22 | `drift_monitor.py` | `python scripts/drift_monitor.py baseline URL` then `compare URL` |
+| GSC performance query (Tier 1) | §10 | `gsc_query.py` | `python scripts/gsc_query.py --property SITE --dimension page --json` |
+| GSC URL inspection export (Tier 1) | §10 | `gsc_export.py` | `python scripts/gsc_export.py --property SITE --sitemap-url URL` |
+| GSC generative-AI impressions (manual CSV) | §10 | `gsc_ai_import.py` | `python scripts/gsc_ai_import.py export.csv --json` |
+| GA4 organic reporting (Tier 1) | §10 | `ga4_report.py` | `python scripts/ga4_report.py --property 123456789 --organic-only --json` |
 | Finding deduplication | §2 | `finding_verifier.py` | `python scripts/finding_verifier.py --findings-json references/finding-verifier-example.json --json` (see `references/finding-verifier-context-example.json` for optional `--context-json`) |
 
 ## Utilities (supporting tools)
@@ -46,6 +57,8 @@ Each major automated check has a **script** you can run alone (usually with `--j
 | `backlink_analyzer.py` | 7-section backlink report from CSV exports (Ahrefs, Moz, Semrush) or built-in sample data (`python scripts/backlink_analyzer.py --source csv --input links.csv --json`) |
 | `score_eval_transcript.py` | Score a saved model reply vs `evals/evals.json` (`--eval-id N` or `--all-fixtures`) |
 | `fetch_page.py` | Fetch HTML to disk for manual inspection |
+| `render_page.py` | Render a page with Playwright (JS-heavy sites) so client-rendered content is visible to the other checkers |
+| `google_api_tier.py` | Report which Google API tier is available from configured credentials (`python scripts/google_api_tier.py --check`) |
 | `check-plugin-sync.py` | CI / release: verify plugin bundle matches repo root |
 
 ## Reference-only areas (no dedicated `.py` checker)

--- a/tests/test_agents_md_size.py
+++ b/tests/test_agents_md_size.py
@@ -1,0 +1,112 @@
+"""AGENTS.md must fit inside Codex's instruction-file budget.
+
+Codex loads AGENTS.md into every session and **silently truncates** at
+`project_doc_max_bytes` (32 KiB by default). There is no warning in the TUI,
+`/stats`, `exec`, or the VS Code extension -- instructions past the cutoff are
+simply never sent to the model.
+
+This repo shipped over that limit for several releases. At 37,238 bytes the
+following were invisible to every Codex user:
+
+  * SS 22 Drift Monitoring, 23 Semantic Clustering, 24 E-commerce, 25 Maps
+  * the Google API Tier System section
+  * the "Full Detail Reference" table -- the map to references/, so the agent
+    could not even find the files it was told to read
+
+The README advertises AGENTS.md compatibility, which made that a correctness
+bug rather than a housekeeping one. This test is the guard.
+
+IMPORTANT -- the real budget is smaller than it looks. `project_doc_max_bytes`
+caps the *combined* size of every instruction file Codex loads across the
+directory hierarchy, not this file alone. A user with their own root AGENTS.md
+spends the same budget. So passing this test is necessary, not sufficient, and
+the headroom below is deliberately treated as a ceiling to stay well under, not
+a target to fill. Codex users who need more can raise the limit in
+~/.codex/config.toml -- documented in README.md.
+"""
+
+import os
+
+import pytest
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+PLUGIN = os.path.join(ROOT, "plugins", "ultimate-seo-geo", "skills", "ultimate-seo-geo")
+
+# Codex's default project_doc_max_bytes.
+CODEX_LIMIT = 32 * 1024
+
+TREES = [("root", ROOT), ("plugin", PLUGIN)]
+
+
+def _size(tree, name):
+    with open(os.path.join(tree, name), "rb") as fh:
+        return len(fh.read())
+
+
+@pytest.mark.parametrize("tree_name,tree", TREES)
+def test_agents_md_fits_codex_budget(tree_name, tree):
+    size = _size(tree, "AGENTS.md")
+    assert size <= CODEX_LIMIT, (
+        f"{tree_name}/AGENTS.md is {size:,} bytes, over Codex's "
+        f"{CODEX_LIMIT:,}-byte default by {size - CODEX_LIMIT:,}.\n"
+        f"Codex truncates SILENTLY -- everything past the cutoff is dropped with no warning.\n"
+        f"Move prose into references/ and leave a pointer; do not delete content. "
+        f"The Routing Index table at the top of AGENTS.md is how the agent finds those files, "
+        f"so it must never be the thing that gets cut."
+    )
+
+
+@pytest.mark.parametrize("tree_name,tree", TREES)
+def test_agents_md_keeps_usable_headroom(tree_name, tree):
+    """Sitting a few bytes under the cap is not actually safe.
+
+    The cap is shared with the user's own instruction files, so a file that
+    only just fits in isolation still truncates in a real project.
+    """
+    size = _size(tree, "AGENTS.md")
+    headroom = CODEX_LIMIT - size
+    assert headroom >= 0, f"{tree_name}/AGENTS.md exceeds the budget entirely ({size:,} bytes)"
+    if headroom < 512:
+        pytest.xfail(
+            f"{tree_name}/AGENTS.md has only {headroom:,} bytes of headroom under the "
+            f"{CODEX_LIMIT:,}-byte cap. It fits alone but will truncate for any user who "
+            f"also has a root AGENTS.md, since project_doc_max_bytes is a combined budget. "
+            f"Known and accepted -- see README.md on raising project_doc_max_bytes."
+        )
+
+
+def test_routing_index_survives_truncation():
+    """The map to references/ must sit well inside the cap.
+
+    Everything else in AGENTS.md is recoverable by reading a reference file --
+    but only if the agent can still see the table telling it which file to read.
+    """
+    with open(os.path.join(ROOT, "AGENTS.md"), "rb") as fh:
+        raw = fh.read()
+    idx = raw.find(b"### Routing Index")
+    assert idx != -1, "AGENTS.md no longer contains a Routing Index"
+    assert idx < 4096, (
+        f"Routing Index starts at byte {idx:,}. It is the agent's map to references/ and "
+        f"must stay near the top of the file, comfortably inside any truncation point."
+    )
+
+
+def test_every_procedure_file_is_reachable_from_agents_md():
+    """A procedure file nothing points at is a file the agent never loads."""
+    import re
+
+    with open(os.path.join(ROOT, "AGENTS.md"), encoding="utf-8") as fh:
+        text = fh.read()
+    referenced = set(re.findall(r"(\d\d-[\w-]+\.md)", text))
+    on_disk = {
+        f for f in os.listdir(os.path.join(ROOT, "references", "procedures"))
+        if re.match(r"\d\d-", f)
+    }
+    assert not (on_disk - referenced), (
+        f"procedure files exist but are unreachable from AGENTS.md: "
+        f"{sorted(on_disk - referenced)}"
+    )
+    assert not (referenced - on_disk), (
+        f"AGENTS.md points at procedure files that do not exist: "
+        f"{sorted(referenced - on_disk)}"
+    )


### PR DESCRIPTION
`AGENTS.md` was **37,238 bytes** against Codex's 32 KiB `project_doc_max_bytes` default. Codex truncates **silently** — no warning in the TUI, `/stats`, `exec`, or the VS Code extension, and everything past the cutoff is never sent to the model.

Since the README advertises AGENTS.md compatibility, this was a correctness bug rather than housekeeping. Five sections were invisible to every Codex user:

- §22 Drift Monitoring, §23 Semantic Clustering, §24 E-commerce, §25 Maps Intelligence
- the Google API Tier System section
- **the "Full Detail Reference" table** — the map to `references/`, so the agent could not find the files it was being told to read

Now **32,726 bytes**, nothing truncated.

## Content was moved, not deleted

| Change | Effect |
|---|---|
| §21's 39-row script inventory (largest section, 5,119 B) → pointer | `references/audit-script-matrix.md` extended from 33 to **all 45** CLI tools |
| Routing Index + Full Detail Reference merged | One `Goal \| Read \| Run \| Procedure` table, now at byte **853** instead of 35,781 |
| Procedure pointers added | All **25** procedure files reachable; four had none, including `19-quality-gates-hard-rules.md` |

Three scripts — `content_quality.py`, `gsc_export.py`, `render_page.py` — were in **no** index at all, so the agent had no way to know they existed. Nine more (`content_brief`, `crux_history`, `drift_monitor`, `ecommerce_schema`, `ga4_report`, `google_api_tier`, `gsc_query`, `maps_checker`, `topic_cluster`) were listed only in the section that truncates.

The merged routing table is the structural half of the fix: everything else in `AGENTS.md` is recoverable by reading a reference file, but only while the agent can still see the table telling it which file to read.

## What I did not paper over

`project_doc_max_bytes` is a **combined** cap across every instruction file Codex loads in the directory hierarchy — this repo's `AGENTS.md` *plus* any the user has further up the tree. **No amount of self-trimming can guarantee fit.** Current headroom is 42 bytes, which is fine in isolation and fragile in a real project.

Rather than cut load-bearing content (the §1 dispatch table, §19 hard rules, §0 mode routing) to manufacture margin, the README now documents the budget, gives the `~/.codex/config.toml` override, and names the symptom to watch for — Codex behaving as though it has never heard of §§22–25, since those truncate first.

The headroom test reflects that honestly: under 512 bytes it **`xfail`s** rather than passing silently.

## Also fixed

- README version badge tracked **1.10.2** through two releases.
- README architecture note claimed `AGENTS.md (~27KB)` when it was 37 KB.

## Verification

- `pytest tests/` — **134 passed, 2 xfailed** (was 130 passed). The xfails are the headroom guard, by design.
- `check-plugin-sync.py` / `check_version_sync.py` — green at **1.12.1**.
- `tests/test_agents_md_size.py` validated by reintroducing each failure mode one at a time: padding the file over the cap, burying the Routing Index deep in the file, and orphaning a procedure file. All three caught; file restored byte-identical afterwards.
- Confirmed post-change that no `## ` section starts past byte 32,768, and that all 25 procedure references resolve to files on disk with none broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)