### PR TITLE
docs: re-check the FAQ Search Console API sunset, record the conflation trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,24 @@
 
 ## [Unreleased]
 
-_Nothing yet._
+### Changed
+
+- **`references/schema-types.md` — FAQ Search Console API sunset re-checked (2026-08-23)** — the reported
+  August 2026 window is now current, so it was re-verified rather than left carried. **Still not
+  confirmable**: Google's changelog has exactly two FAQ entries (May 8, deprecation notice; June 15,
+  documentation removed) and **neither mentions Search Console, the Rich Results Test, or the Search
+  Console API**. The secondary attribution stands.
+  - Recorded the reason this keeps *looking* confirmed: searching Google's changelog for FAQ plus
+    Search Console API surfaces the phased-removal boilerplate and the line *"The Search Console API
+    will continue to support the practice problem type through January 2026"* — which belong to the
+    **practice-problem** deprecation, not FAQ. That deprecation has an identical phased shape (SERP
+    feature → Search Console + Rich Results Test → API last), so it is easy to misattribute, and it is
+    the likeliest source of the secondary reporting's confidence. Documented as a named trap so the
+    next reader does not "confirm" it by accident.
+  - Recorded what would actually settle it: an authenticated `searchanalytics.query` grouped by
+    `searchAppearance` against a property with FAQ history, via `scripts/gsc_query.py` with
+    `GSC_CREDENTIALS` set. No credentials are configured in this repo, and unauthenticated checks
+    cannot answer it.
 
 ## [1.12.1] - 2026-08-23
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/schema-types.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/schema-types.md
@@ -71,12 +71,31 @@ These types no longer generate Google rich results but are still valid Schema.or
 >
 > Only the May 7, 2026 rich-result withdrawal is confirmed by Google's own changelog.
 >
-> **Status as of 2026-08-22.** The reported API window is now current, and re-checking found no Google
-> primary source either confirming or retracting it — the attribution above stands as secondary. Do not
-> report the API sunset as confirmed fact. What *is* actionable: any dashboard, BigQuery export or
-> scheduled job still querying FAQ rich-result data should be checked against live responses now, since
-> the documented failure mode is **silent nulls rather than an error**. A pipeline that "still runs"
-> is not evidence the data is still arriving.
+> **Status as of 2026-08-23 (re-checked).** Still **not confirmable**. Google's own changelog carries
+> only two FAQ entries — May 8, 2026 (deprecation notice; feature gone from Search as of May 7) and
+> June 15, 2026 (FAQ documentation removed). **Neither mentions Search Console, the Rich Results Test,
+> or the Search Console API.** The June/August phase dates exist only in secondary reporting.
+>
+> ⚠ **Known trap — do not "confirm" this by accident.** Searching Google's changelog for FAQ + Search
+> Console API returns text that looks like confirmation:
+> *"we'll also be removing support for that feature in Search Console rich result reporting, the Rich
+> Result Test, and the list of Search appearance filters"* and *"The Search Console API will continue
+> to support the practice problem type through January 2026."*
+> **Those sentences are about the practice-problem deprecation, not FAQ.** That deprecation has an
+> identical phased shape (SERP feature → Search Console + Rich Results Test → API last) and near-identical
+> boilerplate, so it is easy to misattribute — and it is the most likely reason the secondary reporting
+> states the FAQ phases with such confidence. Check which feature an entry names before treating it as
+> evidence.
+>
+> **What would actually settle it**: an authenticated `searchanalytics.query` grouped by
+> `searchAppearance` against a property with FAQ history, checking whether an FAQ value is still
+> returned. `scripts/gsc_query.py` can run it once credentials are configured (`GSC_CREDENTIALS`);
+> unauthenticated checks cannot answer this.
+>
+> **Actionable regardless of confirmation**: any dashboard, BigQuery export or scheduled job still
+> querying FAQ rich-result data should be checked against live responses, because the documented
+> failure mode is **silent nulls rather than an error**. A pipeline that "still runs" is not evidence
+> the data is still arriving.
 
 ## RETIRED — Safe to remove (no longer processed)
 

--- a/references/schema-types.md
+++ b/references/schema-types.md
@@ -71,12 +71,31 @@ These types no longer generate Google rich results but are still valid Schema.or
 >
 > Only the May 7, 2026 rich-result withdrawal is confirmed by Google's own changelog.
 >
-> **Status as of 2026-08-22.** The reported API window is now current, and re-checking found no Google
-> primary source either confirming or retracting it — the attribution above stands as secondary. Do not
-> report the API sunset as confirmed fact. What *is* actionable: any dashboard, BigQuery export or
-> scheduled job still querying FAQ rich-result data should be checked against live responses now, since
-> the documented failure mode is **silent nulls rather than an error**. A pipeline that "still runs"
-> is not evidence the data is still arriving.
+> **Status as of 2026-08-23 (re-checked).** Still **not confirmable**. Google's own changelog carries
+> only two FAQ entries — May 8, 2026 (deprecation notice; feature gone from Search as of May 7) and
+> June 15, 2026 (FAQ documentation removed). **Neither mentions Search Console, the Rich Results Test,
+> or the Search Console API.** The June/August phase dates exist only in secondary reporting.
+>
+> ⚠ **Known trap — do not "confirm" this by accident.** Searching Google's changelog for FAQ + Search
+> Console API returns text that looks like confirmation:
+> *"we'll also be removing support for that feature in Search Console rich result reporting, the Rich
+> Result Test, and the list of Search appearance filters"* and *"The Search Console API will continue
+> to support the practice problem type through January 2026."*
+> **Those sentences are about the practice-problem deprecation, not FAQ.** That deprecation has an
+> identical phased shape (SERP feature → Search Console + Rich Results Test → API last) and near-identical
+> boilerplate, so it is easy to misattribute — and it is the most likely reason the secondary reporting
+> states the FAQ phases with such confidence. Check which feature an entry names before treating it as
+> evidence.
+>
+> **What would actually settle it**: an authenticated `searchanalytics.query` grouped by
+> `searchAppearance` against a property with FAQ history, checking whether an FAQ value is still
+> returned. `scripts/gsc_query.py` can run it once credentials are configured (`GSC_CREDENTIALS`);
+> unauthenticated checks cannot answer this.
+>
+> **Actionable regardless of confirmation**: any dashboard, BigQuery export or scheduled job still
+> querying FAQ rich-result data should be checked against live responses, because the documented
+> failure mode is **silent nulls rather than an error**. A pipeline that "still runs" is not evidence
+> the data is still arriving.
 
 ## RETIRED — Safe to remove (no longer processed)
 


### PR DESCRIPTION
The reported August 2026 window for FAQ data leaving the Search Console API is now current, so it was re-verified rather than left carried as an open question.

## Result: still not confirmable

Google's changelog carries exactly **two** FAQ entries:

- **May 8, 2026** — deprecation notice added; feature gone from Search as of May 7
- **June 15, 2026** — FAQ documentation removed

**Neither mentions Search Console, the Rich Results Test, or the Search Console API.** The June/August phase dates exist only in secondary reporting. The existing attribution stands unchanged — this PR does not upgrade it to confirmed.

## The finding worth having

Searching Google's own changelog for FAQ plus Search Console API returns text that reads exactly like confirmation:

> "we'll also be removing support for that feature in Search Console rich result reporting, the Rich Result Test, and the list of Search appearance filters"

> "The Search Console API will continue to support the practice problem type through January 2026"

**Both belong to the practice-problem deprecation, not FAQ.**

That deprecation has an identical phased shape — SERP feature → Search Console + Rich Results Test → API last — and near-identical boilerplate. It misattributes easily, and it is the likeliest reason the secondary reporting states the FAQ phases with such specificity and confidence.

I nearly recorded it as confirmation before checking which feature the entry actually named. It is now documented as a named trap in `references/schema-types.md`, so the next reader — human or agent — does not "confirm" it by accident. Given this repo's own rule against fabricated certainty, a false confirmation here would have been worse than the open question.

## What would settle it

An authenticated `searchanalytics.query` grouped by `searchAppearance` against a property with FAQ history, checking whether an FAQ value still comes back. `scripts/gsc_query.py` can run it once `GSC_CREDENTIALS` is set. No credentials are configured in this repo, and unauthenticated checks cannot answer the question — that limitation is now stated rather than implied.

## Actionable regardless

Any dashboard, BigQuery export, or scheduled job still querying FAQ rich-result data should be checked against live responses. The documented failure mode is **silent nulls, not an error** — a pipeline that "still runs" is not evidence the data is still arriving.

## Verification

- `pytest tests/` — 134 passed, 2 xfailed
- `check-plugin-sync.py` — green at 1.12.1
- Lands under `[Unreleased]`; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)