### PR TITLE
fix: trim AGENTS.md to 2.5 KiB of headroom, fix a third llms.txt rubric copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,16 +166,6 @@ Do not state metrics unless the corresponding script ran:
 
 **When data is absent:** replace with `[metric] not measured — run [script] for actual data`.
 
-### Audit Process
-
-1. **Fetch** homepage + 5–10 representative pages.
-2. **Detect business type** (SaaS, E-commerce, Local, Publisher, Agency). Load `references/industry-templates.md`.
-3. **Run all audit modules** in sequence.
-4. **Score** using Health Score weights below.
-5. **Assign confidence**: High (8+ pages + analytics) / Medium (4–7 pages) / Low (1–3 pages).
-6. **Audit assumptions** — Before assembling recommendations, list every assumption the audit relies on (e.g., "homepage represents site quality", "CMS is server-rendered"). Surface in the report so the user can reject or correct them. See `references/thinking-framework.md`.
-7. **Prioritize** — Critical → High → Medium → Quick Wins. Apply the PERCEIVE → ANALYZE → VALIDATE → ACT framework to ensure findings are grounded, falsifiable, and dependency-mapped.
-
 ### SEO Health Score Weights
 
 | Category | Weight |
@@ -260,39 +250,22 @@ GEO = getting content cited by AI engines: Google AI Overviews, AI Mode, ChatGPT
 
 | # | Question | If No → Fix |
 |---|---|---|
-| 1 | AI crawlers (OAI-SearchBot, PerplexityBot) allowed in robots.txt? | Remove **only** Disallow rules (or `*` blocks) that block those AI crawlers — see scoped rule below |
+| 1 | AI crawlers (OAI-SearchBot, PerplexityBot) allowed in robots.txt? | Remove **only** Disallow rules (or `*` blocks) that block those AI crawlers — scoped rule in `references/procedures/03-geo-ai-search.md` |
 | 2 | Page answers target query in first 60 words? | Move answer to opening paragraph |
 | 3 | Content in raw HTML (not JS-only)? | Implement SSR |
 | 4 | Named author with credentials + publication date? | Add author bio + date |
 | 5 | Brand mentioned on YouTube or Reddit? | Start presence on missing platform |
 
-### robots.txt: GEO vs traditional crawl directives
-
-- **GEO guidance applies to AI-named crawlers** (e.g. OAI-SearchBot, PerplexityBot, GPTBot, ClaudeBot) and to `User-agent: *` rules that effectively block them from important content.
-- **Do not** recommend removing **Googlebot/Bingbot** `Disallow` rules used for facets (`/*?`), filtered URLs, pagination, category/author paths, or other intentional crawl hygiene **unless** the user explicitly asks for a crawl-budget or indexation review of those rules.
-- `robots_checker.py` focuses on AI crawler status; it does **not** flag facet or low-value-path disallows as errors — do not over-generalize GEO fixes into “remove all Disallow.”
-
 ### GEO Score Components
 
-| Dimension | Weight |
-|---|---|
-| Citability (answer in first 40–60 words, 134–167 word blocks) | 25% |
-| Structural Readability (H1→H2→H3, question headings, tables) | 20% |
-| Authority & Brand Signals (author, date, Wikipedia/Reddit/YouTube) | 20% |
-| Technical Accessibility (AI crawlers, SSR, llms.txt) | 20% |
-| Multi-Modal Content (text + images + video) | 15% |
+Citability 25% · Structural Readability 20% · Authority & Brand Signals 20% · Technical Accessibility
+20% · Multi-Modal Content 15%. Per-dimension checks and scoring detail:
+`references/procedures/03-geo-ai-search.md`. **Technical Accessibility does not include llms.txt** —
+Google confirmed (June 2026) that Search ignores it.
 
-**Key insights:**
-- 44.2% of AI citations come from the first 30% of content.
-- Content under 3 months old receives ~3x AI citation rate (SE Ranking, 2026).
-- AI Overviews and AI Mode share only 13.7% URL overlap — treat as distinct citation engines.
-- Google confirmed (June 2026) that **Search ignores llms.txt** — implement as non-Google AI hygiene only.
+**Key insight**: 44.2% of AI citations come from the first 30% of content.
 
-For full GEO audit steps, citation demonstration pattern, entity optimization, and platform-specific playbooks → read `references/procedures/03-geo-ai-search.md` and `references/ai-search-geo.md`.
-
-Scripts: `robots_checker.py`, `entity_checker.py`, `llms_txt_checker.py`, `social_meta.py`
-
----
+Scripts: `robots_checker.py`, `entity_checker.py`, `preferred_sources_checker.py`, `social_meta.py`
 
 ## 4. Technical SEO
 
@@ -304,24 +277,19 @@ Scripts: `robots_checker.py`, `entity_checker.py`, `llms_txt_checker.py`, `socia
 | **INP** | < 200ms | 200–500ms | > 500ms |
 | **CLS** | < 0.1 | 0.1–0.25 | > 0.25 |
 
+
 ### Key Technical Checks
 
-1. Run PageSpeed Insights (`pagespeed.py`). If it fails, say "performance data unavailable."
-2. Check robots.txt — AI crawlers not disallowed. `Google-Extended` blocks Gemini training only, not Google Search. `GPTBot` blocks training only, not ChatGPT Search (that uses `ChatGPT-User`).
-3. HTTPS everywhere. Mixed content → force via 301.
-4. Canonical tags — self-referencing, absolute URLs, no chains. Run `canonical_checker.py`.
-5. Redirect chains — collapse to direct redirect.
-6. Mobile rendering — touch targets ≥48×48px, font ≥16px.
-7. Soft 404s — `broken_links.py` detects them.
-8. Security headers — HSTS, X-Frame-Options. Run `security_headers.py`.
-9. JavaScript rendering — key content absent from raw HTML = invisible to AI bots.
-10. Open Graph + Twitter Card — `og:title`, `og:description`, `og:image`.
+PageSpeed → robots.txt (AI crawlers not disallowed) → HTTPS → canonicals → redirect chains → orphan
+pages → mobile rendering → soft 404s → JS rendering → Open Graph → security headers. Full 11-step
+procedure with script names: `references/procedures/04-technical-seo.md`.
 
-For full technical audit steps and CWV fix patterns → read `references/procedures/04-technical-seo.md` and `references/technical-checklist.md`.
+**Two distinctions routinely misconfigured**: `Google-Extended` blocks Gemini *training* only — not
+Google Search or AI Overviews. `GPTBot` blocks OpenAI *training* only — ChatGPT Search citations use
+`ChatGPT-User`.
 
-Scripts: `pagespeed.py`, `robots_checker.py`, `redirect_checker.py`, `security_headers.py`, `broken_links.py`, `sitemap_checker.py`
-
----
+**Key rule**: serve canonical, meta robots, structured data, title, meta description and hreflang in
+the **initial server-rendered HTML**, never JS-only.
 
 ## 5. Schema / Structured Data
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@
 
 ### Changed
 
+- **`AGENTS.md` trimmed 32,726 → 30,235 bytes (2.5 KiB headroom, was 42 bytes)** — v1.12.1 got the file
+  under Codex's 32 KiB cap but left it a rounding error from breaching again, and the cap is *combined*
+  across every instruction file Codex loads, so any user with their own root `AGENTS.md` still truncated.
+  Three subsections whose fuller versions already live in `references/procedures/` are replaced with
+  summaries plus pointers: **Audit Process** (§2 → `02-full-site-audit.md`), **GEO Score Components**
+  (§3 → `03-geo-ai-search.md`), and **Key Technical Checks** (§4 → `04-technical-seo.md`). Each target
+  was verified to be a strict superset first. The header threshold, CWV thresholds, evidence-integrity
+  rules, finding format and output template stay inline — those are contracts, not detail.
+  `tests/test_agents_md_size.py::test_agents_md_keeps_usable_headroom` now **passes outright** instead
+  of `xfail`ing.
+
+- **The robots.txt GEO guardrail moved rather than being cut** (`references/procedures/03-geo-ai-search.md`)
+  — the rule against recommending removal of legitimate Googlebot `Disallow` rules (facets, pagination,
+  filtered URLs) existed **only** in `AGENTS.md`. Deleting it would have lost it; it is now in the
+  procedure file, with §3's quick-check table repointed at its new home.
+
+### Fixed
+
+- **A third copy of the llms.txt scoring contradiction, in `AGENTS.md` itself** — v1.12.0 removed
+  llms.txt from the GEO rubrics in `ai-search-geo.md` and `03-geo-ai-search.md`, but `AGENTS.md` §3
+  still read *"Technical Accessibility (AI crawlers, SSR, llms.txt) | 20%"* — with the correct prose
+  ("Search ignores llms.txt") four lines below it. The exact prose-vs-scoring split that file's parity
+  test exists to catch, missed because the test only looked at the two reference files.
+  **`AGENTS.md` is the copy that matters most**, not least: it is what Codex and every other
+  AGENTS.md-compatible tool loads automatically. Surfaced only because the trim required reading the
+  section closely.
+  - `tests/test_geo_signal_parity.py` extended with two `AGENTS.md` guards (rubric excludes llms.txt;
+    the Google position travels with any mention) and `AGENTS.md` added to the byte-identical
+    both-trees check. Validated by reintroducing the exact v1.12.0 bug and confirming it fails.
+
+- **Duplicate step number in `references/procedures/04-technical-seo.md`** — two steps numbered `10`;
+  renumbered to 10/11/12. Spotted while verifying the section was a superset of what `AGENTS.md` carried.
+
 - **`references/schema-types.md` — FAQ Search Console API sunset re-checked (2026-08-23)** — the reported
   August 2026 window is now current, so it was re-verified rather than left carried. **Still not
   confirmable**: Google's changelog has exactly two FAQ entries (May 8, deprecation notice; June 15,

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
@@ -166,16 +166,6 @@ Do not state metrics unless the corresponding script ran:
 
 **When data is absent:** replace with `[metric] not measured — run [script] for actual data`.
 
-### Audit Process
-
-1. **Fetch** homepage + 5–10 representative pages.
-2. **Detect business type** (SaaS, E-commerce, Local, Publisher, Agency). Load `references/industry-templates.md`.
-3. **Run all audit modules** in sequence.
-4. **Score** using Health Score weights below.
-5. **Assign confidence**: High (8+ pages + analytics) / Medium (4–7 pages) / Low (1–3 pages).
-6. **Audit assumptions** — Before assembling recommendations, list every assumption the audit relies on (e.g., "homepage represents site quality", "CMS is server-rendered"). Surface in the report so the user can reject or correct them. See `references/thinking-framework.md`.
-7. **Prioritize** — Critical → High → Medium → Quick Wins. Apply the PERCEIVE → ANALYZE → VALIDATE → ACT framework to ensure findings are grounded, falsifiable, and dependency-mapped.
-
 ### SEO Health Score Weights
 
 | Category | Weight |
@@ -260,39 +250,22 @@ GEO = getting content cited by AI engines: Google AI Overviews, AI Mode, ChatGPT
 
 | # | Question | If No → Fix |
 |---|---|---|
-| 1 | AI crawlers (OAI-SearchBot, PerplexityBot) allowed in robots.txt? | Remove **only** Disallow rules (or `*` blocks) that block those AI crawlers — see scoped rule below |
+| 1 | AI crawlers (OAI-SearchBot, PerplexityBot) allowed in robots.txt? | Remove **only** Disallow rules (or `*` blocks) that block those AI crawlers — scoped rule in `references/procedures/03-geo-ai-search.md` |
 | 2 | Page answers target query in first 60 words? | Move answer to opening paragraph |
 | 3 | Content in raw HTML (not JS-only)? | Implement SSR |
 | 4 | Named author with credentials + publication date? | Add author bio + date |
 | 5 | Brand mentioned on YouTube or Reddit? | Start presence on missing platform |
 
-### robots.txt: GEO vs traditional crawl directives
-
-- **GEO guidance applies to AI-named crawlers** (e.g. OAI-SearchBot, PerplexityBot, GPTBot, ClaudeBot) and to `User-agent: *` rules that effectively block them from important content.
-- **Do not** recommend removing **Googlebot/Bingbot** `Disallow` rules used for facets (`/*?`), filtered URLs, pagination, category/author paths, or other intentional crawl hygiene **unless** the user explicitly asks for a crawl-budget or indexation review of those rules.
-- `robots_checker.py` focuses on AI crawler status; it does **not** flag facet or low-value-path disallows as errors — do not over-generalize GEO fixes into “remove all Disallow.”
-
 ### GEO Score Components
 
-| Dimension | Weight |
-|---|---|
-| Citability (answer in first 40–60 words, 134–167 word blocks) | 25% |
-| Structural Readability (H1→H2→H3, question headings, tables) | 20% |
-| Authority & Brand Signals (author, date, Wikipedia/Reddit/YouTube) | 20% |
-| Technical Accessibility (AI crawlers, SSR, llms.txt) | 20% |
-| Multi-Modal Content (text + images + video) | 15% |
+Citability 25% · Structural Readability 20% · Authority & Brand Signals 20% · Technical Accessibility
+20% · Multi-Modal Content 15%. Per-dimension checks and scoring detail:
+`references/procedures/03-geo-ai-search.md`. **Technical Accessibility does not include llms.txt** —
+Google confirmed (June 2026) that Search ignores it.
 
-**Key insights:**
-- 44.2% of AI citations come from the first 30% of content.
-- Content under 3 months old receives ~3x AI citation rate (SE Ranking, 2026).
-- AI Overviews and AI Mode share only 13.7% URL overlap — treat as distinct citation engines.
-- Google confirmed (June 2026) that **Search ignores llms.txt** — implement as non-Google AI hygiene only.
+**Key insight**: 44.2% of AI citations come from the first 30% of content.
 
-For full GEO audit steps, citation demonstration pattern, entity optimization, and platform-specific playbooks → read `references/procedures/03-geo-ai-search.md` and `references/ai-search-geo.md`.
-
-Scripts: `robots_checker.py`, `entity_checker.py`, `llms_txt_checker.py`, `social_meta.py`
-
----
+Scripts: `robots_checker.py`, `entity_checker.py`, `preferred_sources_checker.py`, `social_meta.py`
 
 ## 4. Technical SEO
 
@@ -304,24 +277,19 @@ Scripts: `robots_checker.py`, `entity_checker.py`, `llms_txt_checker.py`, `socia
 | **INP** | < 200ms | 200–500ms | > 500ms |
 | **CLS** | < 0.1 | 0.1–0.25 | > 0.25 |
 
+
 ### Key Technical Checks
 
-1. Run PageSpeed Insights (`pagespeed.py`). If it fails, say "performance data unavailable."
-2. Check robots.txt — AI crawlers not disallowed. `Google-Extended` blocks Gemini training only, not Google Search. `GPTBot` blocks training only, not ChatGPT Search (that uses `ChatGPT-User`).
-3. HTTPS everywhere. Mixed content → force via 301.
-4. Canonical tags — self-referencing, absolute URLs, no chains. Run `canonical_checker.py`.
-5. Redirect chains — collapse to direct redirect.
-6. Mobile rendering — touch targets ≥48×48px, font ≥16px.
-7. Soft 404s — `broken_links.py` detects them.
-8. Security headers — HSTS, X-Frame-Options. Run `security_headers.py`.
-9. JavaScript rendering — key content absent from raw HTML = invisible to AI bots.
-10. Open Graph + Twitter Card — `og:title`, `og:description`, `og:image`.
+PageSpeed → robots.txt (AI crawlers not disallowed) → HTTPS → canonicals → redirect chains → orphan
+pages → mobile rendering → soft 404s → JS rendering → Open Graph → security headers. Full 11-step
+procedure with script names: `references/procedures/04-technical-seo.md`.
 
-For full technical audit steps and CWV fix patterns → read `references/procedures/04-technical-seo.md` and `references/technical-checklist.md`.
+**Two distinctions routinely misconfigured**: `Google-Extended` blocks Gemini *training* only — not
+Google Search or AI Overviews. `GPTBot` blocks OpenAI *training* only — ChatGPT Search citations use
+`ChatGPT-User`.
 
-Scripts: `pagespeed.py`, `robots_checker.py`, `redirect_checker.py`, `security_headers.py`, `broken_links.py`, `sitemap_checker.py`
-
----
+**Key rule**: serve canonical, meta robots, structured data, title, meta description and hreflang in
+the **initial server-rendered HTML**, never JS-only.
 
 ## 5. Schema / Structured Data
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/procedures/03-geo-ai-search.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/procedures/03-geo-ai-search.md
@@ -49,6 +49,12 @@ For Google AI Mode–specific optimization (zero blue links, follow-up queries, 
 
 For the AI crawler allow/block table (OAI-SearchBot, PerplexityBot, ClaudeBot, GPTBot, Google-Extended) and the llms.txt quick template, see `references/ai-search-geo.md`.
 
+### robots.txt: GEO vs traditional crawl directives
+
+- **GEO guidance applies to AI-named crawlers** (e.g. OAI-SearchBot, PerplexityBot, GPTBot, ClaudeBot) and to `User-agent: *` rules that effectively block them from important content.
+- **Do not** recommend removing **Googlebot/Bingbot** `Disallow` rules used for facets (`/*?`), filtered URLs, pagination, category/author paths, or other intentional crawl hygiene **unless** the user explicitly asks for a crawl-budget or indexation review of those rules.
+- `robots_checker.py` focuses on AI crawler status; it does **not** flag facet or low-value-path disallows as errors — do not over-generalize GEO fixes into “remove all Disallow.”
+
 ### GEO Finding Example
 
 ```

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/procedures/04-technical-seo.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/procedures/04-technical-seo.md
@@ -24,8 +24,8 @@ Measured at 75th percentile (CrUX/PageSpeed Insights). Speed is also a GEO facto
 8. **Check soft 404s** — Run `scripts/broken_links.py` on key pages; it detects pages returning 200 but showing "not found" in `<title>`. Also check `scripts/sitemap_checker.py` output for soft 404s in sitemap. Fix: return real 404/410 or add genuine content.
 9. **Check for broken internal pages** — Run `scripts/internal_links.py` (now reports 404/5xx pages found during crawl) or `scripts/broken_links.py --crawl` for site-wide broken link scan.
 10. **Check JavaScript rendering** — Compare raw source to rendered DOM. Key content JS-only = invisible to AI bots.
-10. **Check Open Graph + Twitter Card** — `og:title`, `og:description`, `og:image`, `twitter:card` on all shareable pages.
-11. **Check security headers** — HSTS, X-Frame-Options, X-Content-Type-Options. ✅ Pass: `Strict-Transport-Security: max-age=31536000; includeSubDomains`. ❌ Fail: header absent or `max-age=0`.
+11. **Check Open Graph + Twitter Card** — `og:title`, `og:description`, `og:image`, `twitter:card` on all shareable pages.
+12. **Check security headers** — HSTS, X-Frame-Options, X-Content-Type-Options. ✅ Pass: `Strict-Transport-Security: max-age=31536000; includeSubDomains`. ❌ Fail: header absent or `max-age=0`.
 
 For the full Critical Technical Issues + Fix Directives table (9 issues with detection methods and fixes), JavaScript SEO December 2025 clarifications (canonical conflicts, noindex behavior, JS-rendered structured data), and the mobile-first indexing note, see `references/technical-checklist.md`.
 

--- a/references/procedures/03-geo-ai-search.md
+++ b/references/procedures/03-geo-ai-search.md
@@ -49,6 +49,12 @@ For Google AI Mode–specific optimization (zero blue links, follow-up queries, 
 
 For the AI crawler allow/block table (OAI-SearchBot, PerplexityBot, ClaudeBot, GPTBot, Google-Extended) and the llms.txt quick template, see `references/ai-search-geo.md`.
 
+### robots.txt: GEO vs traditional crawl directives
+
+- **GEO guidance applies to AI-named crawlers** (e.g. OAI-SearchBot, PerplexityBot, GPTBot, ClaudeBot) and to `User-agent: *` rules that effectively block them from important content.
+- **Do not** recommend removing **Googlebot/Bingbot** `Disallow` rules used for facets (`/*?`), filtered URLs, pagination, category/author paths, or other intentional crawl hygiene **unless** the user explicitly asks for a crawl-budget or indexation review of those rules.
+- `robots_checker.py` focuses on AI crawler status; it does **not** flag facet or low-value-path disallows as errors — do not over-generalize GEO fixes into “remove all Disallow.”
+
 ### GEO Finding Example
 
 ```

--- a/references/procedures/04-technical-seo.md
+++ b/references/procedures/04-technical-seo.md
@@ -24,8 +24,8 @@ Measured at 75th percentile (CrUX/PageSpeed Insights). Speed is also a GEO facto
 8. **Check soft 404s** — Run `scripts/broken_links.py` on key pages; it detects pages returning 200 but showing "not found" in `<title>`. Also check `scripts/sitemap_checker.py` output for soft 404s in sitemap. Fix: return real 404/410 or add genuine content.
 9. **Check for broken internal pages** — Run `scripts/internal_links.py` (now reports 404/5xx pages found during crawl) or `scripts/broken_links.py --crawl` for site-wide broken link scan.
 10. **Check JavaScript rendering** — Compare raw source to rendered DOM. Key content JS-only = invisible to AI bots.
-10. **Check Open Graph + Twitter Card** — `og:title`, `og:description`, `og:image`, `twitter:card` on all shareable pages.
-11. **Check security headers** — HSTS, X-Frame-Options, X-Content-Type-Options. ✅ Pass: `Strict-Transport-Security: max-age=31536000; includeSubDomains`. ❌ Fail: header absent or `max-age=0`.
+11. **Check Open Graph + Twitter Card** — `og:title`, `og:description`, `og:image`, `twitter:card` on all shareable pages.
+12. **Check security headers** — HSTS, X-Frame-Options, X-Content-Type-Options. ✅ Pass: `Strict-Transport-Security: max-age=31536000; includeSubDomains`. ❌ Fail: header absent or `max-age=0`.
 
 For the full Critical Technical Issues + Fix Directives table (9 issues with detection methods and fixes), JavaScript SEO December 2025 clarifications (canonical conflicts, noindex behavior, JS-rendered structured data), and the mobile-first indexing note, see `references/technical-checklist.md`.
 

--- a/tests/test_geo_signal_parity.py
+++ b/tests/test_geo_signal_parity.py
@@ -122,9 +122,48 @@ def test_llms_checker_states_it_is_not_a_google_signal(tree_name, tree):
     )
 
 
+@pytest.mark.parametrize("tree_name,tree", TREES)
+def test_agents_md_geo_rubric_excludes_llms_txt(tree_name, tree):
+    """AGENTS.md carries a third copy of the GEO rubric, and it was missed.
+
+    v1.12.0 removed llms.txt from the rubrics in ai-search-geo.md and
+    03-geo-ai-search.md, but AGENTS.md § 3 still read
+    "Technical Accessibility (AI crawlers, SSR, llms.txt) | 20%" -- with the
+    correct prose ("Search ignores llms.txt") four lines below it, the exact
+    prose-vs-scoring split this file exists to catch. The original tests only
+    looked at the two reference files, so they passed over it.
+
+    AGENTS.md matters more than either, not less: it is the file Codex and every
+    other AGENTS.md-compatible tool loads automatically.
+    """
+    text = _read(tree, "AGENTS.md")
+    offenders = [
+        line for line in text.splitlines()
+        if "llms" in line.lower()
+        and "%" in line
+        and re.search(r"technical accessibility", line, re.I)
+    ]
+    assert not offenders, (
+        f"{tree_name}/AGENTS.md scores llms.txt as a Technical Accessibility signal, but "
+        f"Google Search ignores it (June 2026).\nOffending line(s): {offenders}"
+    )
+
+
+@pytest.mark.parametrize("tree_name,tree", TREES)
+def test_agents_md_states_google_ignores_llms_txt(tree_name, tree):
+    """Wherever AGENTS.md raises llms.txt, the Google position travels with it."""
+    text = _read(tree, "AGENTS.md")
+    if "llms.txt" not in text:
+        pytest.skip(f"{tree_name}/AGENTS.md does not mention llms.txt")
+    assert any(re.search(p, text, re.I) for p in DISCLAIMER_PATTERNS), (
+        f"{tree_name}/AGENTS.md mentions llms.txt without stating that Google Search ignores it."
+    )
+
+
 def test_both_trees_agree_on_geo_signal_files():
     """Root and plugin bundle must be byte-identical for every file guarded here."""
     guarded = [rel for _, rel in RUBRIC_FILES] + [
+        "AGENTS.md",
         os.path.join("scripts", "generate_report.py"),
         os.path.join("scripts", "llms_txt_checker.py"),
     ]


### PR DESCRIPTION
v1.12.1 got `AGENTS.md` under Codex's 32 KiB cap but left **42 bytes** of margin — and that cap is *combined* across every instruction file Codex loads, so any user with their own root `AGENTS.md` still truncated. Now **30,235 bytes, 2.5 KiB spare**.

## Why not the nested split

This started as a nested-`AGENTS.md` split. Checking the mechanism first showed it would have made things **worse**. From OpenAI's docs:

> "Codex does **not** automatically descend into subdirectories below your current location. The discovery process terminates at your working directory."

Codex walks *upward* from cwd. Content moved into `references/AGENTS.md` would load only when the user's cwd was inside `references/` — which never happens for this tool, where people `cd ultimate-seo-geo` and ask for an audit. That's content going from *"loaded, near the edge"* to *"never loaded"*, silently undoing #23.

The pointer architecture is the right shape here precisely because the agent **reads** reference files as tool calls, which works regardless of cwd. That's also why guaranteeing the Routing Index survives (byte 853) mattered more than the byte count.

## What was trimmed

Three subsections whose fuller versions already live in `references/procedures/`, each **verified a strict superset first**:

| Removed from | Full version now at |
|---|---|
| §2 Audit Process | `02-full-site-audit.md` |
| §3 GEO Score Components | `03-geo-ai-search.md` |
| §4 Key Technical Checks | `04-technical-seo.md` |

Contracts stay inline — Health Score weights, CWV thresholds, evidence integrity, finding format, output template. Those are what the agent must *emit*, not detail it can look up.

**The robots.txt GEO guardrail was moved, not cut.** The rule against recommending removal of legitimate Googlebot `Disallow` rules (facets, pagination, filtered URLs) existed **only** in `AGENTS.md` — deleting it would have lost it outright. It's now in `03-geo-ai-search.md`, with §3's quick-check table repointed at its new home.

## The bug this surfaced

`AGENTS.md` §3 still read:

> `| Technical Accessibility (AI crawlers, SSR, llms.txt) | 20% |`

A **third copy** of the contradiction v1.12.0 fixed in the two reference files — sitting four lines above the correct prose ("Search ignores llms.txt"). The exact prose-vs-scoring split that `test_geo_signal_parity.py` exists to catch, missed because the test only looked at the reference files.

`AGENTS.md` is the copy that matters *most*, not least: it's what Codex and every other AGENTS.md-compatible tool loads automatically. It surfaced only because trimming required reading the section closely — a decent argument that the "no change needed" verdict on a file is worth less than actually editing it.

Test extended with two `AGENTS.md` guards and added to the byte-identical both-trees check. **Validated by reintroducing the exact v1.12.0 bug** and confirming it fails in both trees.

## Also

Duplicate step number in `04-technical-seo.md` — two steps numbered `10`, renumbered 10/11/12. Spotted while verifying that section was a superset.

## Verification

- `pytest tests/` — **140 passed, 0 xfailed** (was 134 + 2 xfailed; the headroom test now passes outright instead of xfailing on a 42-byte margin)
- No `## ` section starts past byte 32,768; Routing Index still at byte 853
- All **25** procedure references resolve, none broken, none orphaned
- No dangling "see scoped rule below" pointers
- All section numbers §1–§25 still present
- `check-plugin-sync.py` green at 1.12.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)