### PR TITLE
chore: release 1.12.2 — fold [Unreleased] and bump version

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
     "name": "Myk Pono"
   },
   "metadata": {
-    "version": "1.12.1"
+    "version": "1.12.2"
   },
   "plugins": [
     {
       "name": "ultimate-seo-geo",
       "description": "Scored SEO audits for developers/marketers using AI agents: technical health, JSON-LD, E-E-A-T, backlinks, GEO (AI Overviews, ChatGPT, Perplexity). 46 scripts; HTML/Excel/PDF. E-commerce schema, drift monitoring, topic clustering, Google API tiers, maps intelligence. Optional MCP (Firecrawl, DataForSEO). Parallel workers: agents/PARALLEL-AUDIT.md. Modes: Audit → Plan → Execute.",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "author": {
         "name": "Myk Pono",
         "url": "https://lab.mykpono.com"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.1 |
+| **Version** | 1.12.2 |
 | **Updated** | 2026-08-22 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [1.12.2] - 2026-08-23
+
+Follow-up to 1.12.1, which landed the Codex size fix but left `AGENTS.md` 42 bytes under a cap that
+is **combined** across every instruction file Codex loads — still truncating for anyone carrying
+their own root `AGENTS.md`. This takes the margin to 2.5 KiB and fixes a third copy of the llms.txt
+scoring contradiction that the trim exposed inside `AGENTS.md` itself.
+
 ### Changed
 
 - **`AGENTS.md` trimmed 32,726 → 30,235 bytes (2.5 KiB headroom, was 42 bytes)** — v1.12.1 got the file
@@ -20,23 +29,6 @@
   filtered URLs) existed **only** in `AGENTS.md`. Deleting it would have lost it; it is now in the
   procedure file, with §3's quick-check table repointed at its new home.
 
-### Fixed
-
-- **A third copy of the llms.txt scoring contradiction, in `AGENTS.md` itself** — v1.12.0 removed
-  llms.txt from the GEO rubrics in `ai-search-geo.md` and `03-geo-ai-search.md`, but `AGENTS.md` §3
-  still read *"Technical Accessibility (AI crawlers, SSR, llms.txt) | 20%"* — with the correct prose
-  ("Search ignores llms.txt") four lines below it. The exact prose-vs-scoring split that file's parity
-  test exists to catch, missed because the test only looked at the two reference files.
-  **`AGENTS.md` is the copy that matters most**, not least: it is what Codex and every other
-  AGENTS.md-compatible tool loads automatically. Surfaced only because the trim required reading the
-  section closely.
-  - `tests/test_geo_signal_parity.py` extended with two `AGENTS.md` guards (rubric excludes llms.txt;
-    the Google position travels with any mention) and `AGENTS.md` added to the byte-identical
-    both-trees check. Validated by reintroducing the exact v1.12.0 bug and confirming it fails.
-
-- **Duplicate step number in `references/procedures/04-technical-seo.md`** — two steps numbered `10`;
-  renumbered to 10/11/12. Spotted while verifying the section was a superset of what `AGENTS.md` carried.
-
 - **`references/schema-types.md` — FAQ Search Console API sunset re-checked (2026-08-23)** — the reported
   August 2026 window is now current, so it was re-verified rather than left carried. **Still not
   confirmable**: Google's changelog has exactly two FAQ entries (May 8, deprecation notice; June 15,
@@ -53,6 +45,23 @@
     `searchAppearance` against a property with FAQ history, via `scripts/gsc_query.py` with
     `GSC_CREDENTIALS` set. No credentials are configured in this repo, and unauthenticated checks
     cannot answer it.
+
+### Fixed
+
+- **A third copy of the llms.txt scoring contradiction, in `AGENTS.md` itself** — v1.12.0 removed
+  llms.txt from the GEO rubrics in `ai-search-geo.md` and `03-geo-ai-search.md`, but `AGENTS.md` §3
+  still read *"Technical Accessibility (AI crawlers, SSR, llms.txt) | 20%"* — with the correct prose
+  ("Search ignores llms.txt") four lines below it. The exact prose-vs-scoring split that file's parity
+  test exists to catch, missed because the test only looked at the two reference files.
+  **`AGENTS.md` is the copy that matters most**, not least: it is what Codex and every other
+  AGENTS.md-compatible tool loads automatically. Surfaced only because the trim required reading the
+  section closely.
+  - `tests/test_geo_signal_parity.py` extended with two `AGENTS.md` guards (rubric excludes llms.txt;
+    the Google position travels with any mention) and `AGENTS.md` added to the byte-identical
+    both-trees check. Validated by reintroducing the exact v1.12.0 bug and confirming it fails.
+
+- **Duplicate step number in `references/procedures/04-technical-seo.md`** — two steps numbered `10`;
+  renumbered to 10/11/12. Spotted while verifying the section was a superset of what `AGENTS.md` carried.
 
 ## [1.12.1] - 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![AGENTS.md](https://img.shields.io/badge/AGENTS.md-compatible-blue)](https://agents.md)
-[![Version](https://img.shields.io/badge/version-1.12.1-green.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.12.2-green.svg)](CHANGELOG.md)
 [![LLM-Agnostic](https://img.shields.io/badge/LLM--Agnostic-7%2B%20platforms-purple.svg)](#platform-compatibility)
 
 The definitive SEO and Generative Engine Optimization agent for AI coding tools. LLM-agnostic — works on any platform that reads `AGENTS.md`. Runs full site audits with scored findings, generates ready-to-deploy fixes, and optimizes content for both Google Search and AI search engines (Google AI Overviews, AI Mode, ChatGPT Search, Perplexity). Exports HTML, Excel, and PDF reports.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ultimate-seo-geo
 description: Audits and optimizes websites for search engine visibility (SEO) and AI search citation (GEO), covering technical health, E-E-A-T content scoring, domain authority, structured data, rich results, and entity signals. Use when running SEO audits, diagnosing traffic drops or ranking losses, generating Schema.org JSON-LD, checking Core Web Vitals, crawlability, robots.txt, sitemaps, hreflang, backlinks, planning content strategy or site migrations, fixing indexing issues, or optimizing for AI Overviews, ChatGPT, and Perplexity. NOT for paid ads (PPC/SEM), social media strategy, email marketing, or general web development unrelated to search.
-version: 1.12.1
+version: 1.12.2
 ---
 
 # Ultimate SEO + GEO — LLM-Agnostic SEO Agent
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.1 |
+| **Version** | 1.12.2 |
 | **Updated** | 2026-08-12 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/plugins/ultimate-seo-geo/.claude-plugin/plugin.json
+++ b/plugins/ultimate-seo-geo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ultimate-seo-geo",
   "description": "Scored SEO audits for developers and marketers using AI agents: technical health, Schema.org JSON-LD, E-E-A-T, backlinks, domain signals, GEO (AI Overviews, ChatGPT, Perplexity). 46 bundled scripts; HTML/Excel/PDF reports. E-commerce schema, drift monitoring, topic clustering, Google API tiers (GSC/GA4), maps intelligence. Optional MCP (Firecrawl, DataForSEO): references/optional-extensions-mcp.md. Modes: Audit → Plan → Execute.",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "author": {
     "name": "Myk Pono",
     "url": "https://lab.mykpono.com"

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
@@ -2,7 +2,7 @@
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.1 |
+| **Version** | 1.12.2 |
 | **Updated** | 2026-08-22 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/SKILL.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ultimate-seo-geo
 description: Audits and optimizes websites for search engine visibility (SEO) and AI search citation (GEO), covering technical health, E-E-A-T content scoring, domain authority, structured data, rich results, and entity signals. Use when running SEO audits, diagnosing traffic drops or ranking losses, generating Schema.org JSON-LD, checking Core Web Vitals, crawlability, robots.txt, sitemaps, hreflang, backlinks, planning content strategy or site migrations, fixing indexing issues, or optimizing for AI Overviews, ChatGPT, and Perplexity. NOT for paid ads (PPC/SEM), social media strategy, email marketing, or general web development unrelated to search.
-version: 1.12.1
+version: 1.12.2
 ---
 
 # Ultimate SEO + GEO — LLM-Agnostic SEO Agent
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.1 |
+| **Version** | 1.12.2 |
 | **Updated** | 2026-08-12 |
 | **License** | MIT |
 | **Author** | Myk Pono |


### PR DESCRIPTION
`main` sat **4 commits ahead** of the `v1.12.1` tag carrying real fixes the published release doesn't describe: the `AGENTS.md` deeper trim, the third llms.txt rubric copy, and the FAQ API re-check.

## What's in it

- `[Unreleased]` folded into **`[1.12.2]` — 2026-08-23**, with a lead explaining why a follow-up to 1.12.1 exists at all: 1.12.1 landed the Codex size fix but left 42 bytes under a cap that is *combined* across every instruction file Codex loads, so it still truncated for anyone carrying their own root `AGENTS.md`.
- Version bumped **1.12.1 → 1.12.2** across `SKILL.md` (×2), `AGENTS.md`, `README.md`, `marketplace.json` (×2), `plugin.json`.
- `[Unreleased]` is empty again.

## Misfiling corrected

Found while reading the section: the **FAQ re-check** entry was filed under `### Changed` by #26, but #27's edit consumed that subsection header and stranded the entry under `### Fixed`. It re-verifies documentation status and fixes nothing — moved back to `Changed`.

## Verification

- All **5** bullets preserved through the fold (5 before, 5 after, none lost) — checked programmatically against `HEAD:CHANGELOG.md`
- FAQ entry confirmed under `Changed`
- `AGENTS.md` unchanged at **30,235 bytes** (the bump is same-length, so no size impact)
- `pytest tests/` — **140 passed**
- `check-plugin-sync.py` and `check_version_sync.py` — green at **1.12.2**
- Release notes extraction verified: **59 clean lines**

## After merge — yours to run

Tagging and release creation are on the agent prohibition list:

```bash
git checkout main && git pull && git tag v1.12.2 && git push origin v1.12.2
```

```bash
gh release create v1.12.2 --title "v1.12.2 — AGENTS.md headroom, third llms.txt rubric copy" --notes "$(sed -n '/^## \[1.12.2\]/,/^## \[1.12.1\]/p' CHANGELOG.md | sed '$d')"
```

No `grep -v '^> '` needed this time — the 1.12.2 lead is plain prose, not a blockquote. Creating the release moves the `Latest` badge off v1.12.1 automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)