### PR TITLE
fix: re-review the five "verified" reference files — defects in all five

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -454,7 +454,7 @@ Condensed below; full rule text and rationale in `references/procedures/19-quali
 - **AI citation ≠ ranking** — 85% of retrieved pages never cited. Being retrieved is necessary but not sufficient.
 - **Mentions > Backlinks for AI** — 0.664 vs. 0.218 correlation.
 - **Blocking AI crawlers harms GEO** — removes site from AI search entirely.
-- **GPTBot ≠ training only** — blocking also limits ChatGPT Search citation.
+- **GPTBot *is* training-only** — blocking it does **not** affect ChatGPT Search citation. `OAI-SearchBot` governs that; `ChatGPT-User` handles live fetches. Blocking one has no effect on the others.
 - **Google Search ignores llms.txt** — confirmed June 2026. Implement as non-Google AI hygiene only.
 - **AI Mode is a distinct citation engine** — only 13.7% URL overlap with AI Overviews (Ahrefs, 540K query pairs). Optimize separately.
 - **Content recency boosts AI citations** — content under 3 months old receives ~3x citation rate (SE Ranking, 2026).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,57 @@
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+Re-review of the five reference files that v1.12.2's predecessor marked *"verified, no change
+needed."* That verdict came from a grep for date-bearing and externally-sourced claims. Reading the
+files end to end found defects in **all five**, plus three contradictions they exposed elsewhere.
+The labels are corrected in place to say what the earlier pass actually did.
+
+- **A § 19 hard rule was factually wrong** (`19-quality-gates-hard-rules.md`, `AGENTS.md` § 18) —
+  *"GPTBot ≠ training only. Blocking it also limits ChatGPT Search citation. Users who block GPTBot
+  expecting only training-opt-out lose live search visibility."* OpenAI runs three independent
+  agents: `GPTBot` (training), `OAI-SearchBot` (ChatGPT Search index), `ChatGPT-User` (live
+  fetches). **Blocking one has no effect on the others.** `04-technical-seo.md` stated this
+  correctly a few files away. The rule told site owners that opting out of model training costs
+  them ChatGPT visibility — foreclosing a real licensing decision on a false premise. It survived in
+  the *myths* section, where readers go specifically to have misconceptions corrected.
+  - `tests/test_crawler_claims.py` added: 14 tests across both trees barring the false phrasing and
+    requiring the § 19 rule to name `OAI-SearchBot`. Validated by reintroducing the original wording.
+
+- **`keyword-strategy.md` priority formula could never produce its own top tier** — documented as
+  `Σ(Factor Weight × Score) / 5` with weights summing to 100% and scores 1–5. The weighted sum
+  already lands on 1–5; the `÷5` capped the maximum at **1.00**, which the priority table classifies
+  as *"P3 — track but don't prioritize."* A perfect keyword scored lowest. Division removed.
+
+- **`cite-domain-rating.md` and `core-eeat-framework.md` graded perfection as "Poor"** — items score
+  0/5/10, so dimension averages and the weighted total land on **0–10**, while the grade bands are
+  **0–100**. No normalisation was stated. A page or domain passing every item scores 10 and reads as
+  *"0–39 Poor"*. Both now specify ×10 before reading the bands.
+
+- **`site-migration.md` shipped an SSRF vector the repo had already closed** — an inline redirect
+  validator looping a migration map through `requests.get(old_url, allow_redirects=True)` with no
+  URL validation. That is exactly what `validate_url()` was added to `redirect_checker.py` to
+  prevent in v1.10.2: a redirect map is attacker-influenced input, and one `Location:` header
+  pointing at `169.254.169.254` walks the checker into a cloud metadata endpoint. Replaced with the
+  shipped `redirect_checker.py`, which validates per hop.
+  - Also: `scripts/crawl_urls.py` does not exist (→ `site_mapper.py`), and "resolve in ≤ 2 hops"
+    contradicted the same file's redirect-map rule and Common Mistakes table, both requiring
+    single-hop.
+
+- **`entity-optimization.md` signal 36 named the training-only crawler** — measuring AI *recognition*
+  (signals 28–29) while checking `GPTBot`, which has no bearing on it. Now names `OAI-SearchBot`,
+  `ChatGPT-User`, `PerplexityBot` and `ClaudeBot`.
+  - Its AI Entity Resolution Test also collapsed AI Overviews and AI Mode into one column, though
+    this repo documents them as distinct citation engines sharing only 13.7% URL overlap — hiding
+    exactly the gap the test exists to find. Split into separate columns; bands rescaled /48 → /60
+    with the original proportions preserved (75/50/25%).
+
+- **Sitelinks Searchbox presented as a live feature in three places** — `schema-types.md` records it
+  as removed from the Search UI in January 2026, yet `industry-templates.md` recommended `WebSite`
+  schema *for* it (×2), `schema-types.md` itself described it in the present tense, and
+  `analytics-reporting.md` listed its Search Console enhancement report. Corrected without
+  recommending removal of the markup, per § 19 rule 10.
 
 ## [1.12.2] - 2026-08-23
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
@@ -454,7 +454,7 @@ Condensed below; full rule text and rationale in `references/procedures/19-quali
 - **AI citation ≠ ranking** — 85% of retrieved pages never cited. Being retrieved is necessary but not sufficient.
 - **Mentions > Backlinks for AI** — 0.664 vs. 0.218 correlation.
 - **Blocking AI crawlers harms GEO** — removes site from AI search entirely.
-- **GPTBot ≠ training only** — blocking also limits ChatGPT Search citation.
+- **GPTBot *is* training-only** — blocking it does **not** affect ChatGPT Search citation. `OAI-SearchBot` governs that; `ChatGPT-User` handles live fetches. Blocking one has no effect on the others.
 - **Google Search ignores llms.txt** — confirmed June 2026. Implement as non-Google AI hygiene only.
 - **AI Mode is a distinct citation engine** — only 13.7% URL overlap with AI Overviews (Ahrefs, 540K query pairs). Optimize separately.
 - **Content recency boosts AI citations** — content under 3 months old receives ~3x citation rate (SE Ranking, 2026).

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/analytics-reporting.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/analytics-reporting.md
@@ -125,7 +125,7 @@ GSC shows CrUX (real user) data, which is what Google uses for rankings:
 
 - **Rich results**: Eligible vs. Valid vs. Error by schema type
 - **Breadcrumbs**: Structured data parsing errors
-- **Sitelinks searchbox**: If applicable
+- ~~**Sitelinks searchbox**~~: retired — the feature was removed from the Search UI in January 2026, so this enhancement report no longer appears
 
 ---
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/cite-domain-rating.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/cite-domain-rating.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: verified, no change needed — audited for Google-behaviour claims and externally-sourced statistics; contains neither. All numeric values are internal rubric thresholds, which do not decay. Date reflects that audit, not a rewrite. -->
+<!-- 2026-08-23 review: SUPERSEDED by the 2026-08-23 re-review. The earlier pass marked this file 'verified, no change needed' on the basis of a grep for date-bearing and externally-sourced claims. Reading it end to end found: items score 0-10 while grade bands are 0-100 with no normalisation stated — a perfect domain graded 'Poor'. Scanning is not review. -->
 <!-- Source: domain-authority-auditor skill (aaron-he-zhu/cite-domain-rating) -->
 
 # CITE Domain Authority Rating Framework
@@ -21,7 +21,12 @@
 | **Fail** | 0 |
 | **N/A** | Excluded from dimension average |
 
-**CITE Score** = weighted average of all 4 dimensions using domain-type weights below.
+**CITE Score** = weighted average of all 4 dimensions using domain-type weights below, **×10** to put it on the 0–100 band scale.
+
+> **Scale note.** Items score 0/5/10, so a dimension average and the weighted total both land on a
+> **0–10** scale. The grade bands below are **0–100**. Multiply the weighted total by 10 before
+> reading the bands — otherwise a domain passing every item scores 10 and reads as "Poor".
+
 
 **N/A handling**: Same as CORE-EEAT — if >50% of items in a dimension are N/A, mark "Insufficient Data" and redistribute weight.
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/core-eeat-framework.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/core-eeat-framework.md
@@ -23,7 +23,12 @@
 
 **GEO Score** = average of CORE dimensions (C + O + R + E) / 4
 **SEO Score** = average of EEAT dimensions (Exp + Ept + A + T) / 4
-**Total Score** = weighted average using content-type weights below
+**Total Score** = weighted average using content-type weights below, **×10** to put it on the 0–100 band scale
+
+> **Scale note.** Items score 0/5/10, so a dimension average and the weighted total both land on a
+> **0–10** scale. The grade bands below are **0–100**. Multiply the weighted total by 10 before
+> reading the bands — otherwise a page passing every item scores 10 and reads as "Poor".
+
 
 **N/A handling**: If >50% of items in a dimension are N/A, mark the dimension as "Insufficient Data" and exclude it — redistribute its weight proportionally to remaining dimensions.
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/entity-optimization.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/entity-optimization.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: verified, no change needed — audited for Google-behaviour claims and externally-sourced statistics; contains neither. All numeric values are internal rubric thresholds, which do not decay. Date reflects that audit, not a rewrite. -->
+<!-- 2026-08-23 review: SUPERSEDED by the 2026-08-23 re-review. The earlier pass marked this file 'verified, no change needed' on the basis of a grep for date-bearing and externally-sourced claims. Reading it end to end found: signal 36 named the training-only crawler; AI Overviews/AI Mode collapsed into one column despite being distinct citation engines (bands rescaled /48 -> /60). Scanning is not review. -->
 <!-- Source: entity-optimizer skill (aaron-he-zhu) -->
 
 # Entity Optimization — Knowledge Graph, Brand Entity & AI Recognition
@@ -38,22 +38,27 @@ For each query × platform combination, score:
 
 ### Results Template
 
-| Query | ChatGPT | Perplexity | Google AI Overview | Claude |
-|---|---|---|---|---|
-| "What is [Entity]?" | X/3 | X/3 | X/3 | X/3 |
-| "Who founded [Entity]?" | X/3 | X/3 | X/3 | X/3 |
-| "How does [Entity] compare to [Competitor]?" | X/3 | X/3 | X/3 | X/3 |
-| "[Entity]'s approach to [Topic]" | X/3 | X/3 | X/3 | X/3 |
-| **Platform Total** | /12 | /12 | /12 | /12 |
+| Query | ChatGPT | Perplexity | Google AI Overviews | Google AI Mode | Claude |
+|---|---|---|---|---|---|
+| "What is [Entity]?" | X/3 | X/3 | X/3 | X/3 | X/3 |
+| "Who founded [Entity]?" | X/3 | X/3 | X/3 | X/3 | X/3 |
+| "How does [Entity] compare to [Competitor]?" | X/3 | X/3 | X/3 | X/3 | X/3 |
+| "[Entity]'s approach to [Topic]" | X/3 | X/3 | X/3 | X/3 | X/3 |
+| **Platform Total** | /12 | /12 | /12 | /12 | /12 |
 
-**Overall Entity Recognition Score**: /48
+**Overall Entity Recognition Score**: /60
+
+**AI Overviews and AI Mode are scored separately on purpose.** They share only 13.7% URL overlap
+(Ahrefs, 540K query pairs), so they are distinct citation engines — an entity can be well recognised
+in one and absent from the other. Collapsing them into a single "Google" column hides exactly the
+gap this test exists to find.
 
 | Score Range | Assessment | Action |
 |---|---|---|
-| 36–48 | Strong recognition | Maintain and refine accuracy |
-| 24–35 | Moderate recognition | Fill specific gaps identified |
-| 12–23 | Weak recognition | Prioritize foundation signals |
-| 0–11 | Not recognized | Full entity building program needed |
+| 45–60 | Strong recognition | Maintain and refine accuracy |
+| 30–44 | Moderate recognition | Fill specific gaps identified |
+| 15–29 | Weak recognition | Prioritize foundation signals |
+| 0–14 | Not recognized | Full entity building program needed |
 
 ---
 
@@ -139,7 +144,7 @@ For each query × platform combination, score:
 | 33 | Entity definition quotable in first paragraph | Clear "X is..." definition in opening of about/homepage | Definition buried or missing |
 | 34 | Factual claims verifiable | Key claims have authoritative sources | Unsourced claims |
 | 35 | Entity name used consistently | Same entity name across all platforms and content | Name variations causing confusion |
-| 36 | Content crawlable by AI systems | AI crawlers (GPTBot, PerplexityBot) allowed in robots.txt | AI crawlers blocked |
+| 36 | Content crawlable by AI systems | The crawlers that govern *recognition* are allowed: `OAI-SearchBot` (ChatGPT Search), `ChatGPT-User` (live fetches), `PerplexityBot`, `ClaudeBot`. `GPTBot` is training-only and does **not** affect signals 28–29 | Search/fetch crawlers blocked |
 | 37 | Fresh information available | Key pages updated within last 6 months | Stale content (12+ months) |
 
 ### Priority 4: Advanced Signals (Nice-to-Have) — Signals 38–47

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/industry-templates.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/industry-templates.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: verified, no change needed — audited for Google-behaviour claims and externally-sourced statistics; contains neither. All numeric values are internal rubric thresholds, which do not decay. Date reflects that audit, not a rewrite. -->
+<!-- 2026-08-23 review: SUPERSEDED by the 2026-08-23 re-review. The earlier pass marked this file 'verified, no change needed' on the basis of a grep for date-bearing and externally-sourced claims. Reading it end to end found: recommended WebSite schema *for* the Sitelinks Searchbox, removed from the Search UI in January 2026. Scanning is not review. -->
 
 # Industry-Specific SEO Templates
 
@@ -38,7 +38,7 @@ Load when § 2 business type detection identifies a specific industry.
 
 | Page Type | Schema |
 |---|---|
-| Homepage | `WebApplication` or `SoftwareApplication`, `Organization`, `WebSite` (Sitelinks Searchbox) |
+| Homepage | `WebApplication` or `SoftwareApplication`, `Organization`, `WebSite` |
 | Feature pages | `SoftwareApplication`, `FAQPage` |
 | Pricing | `Offer`, `FAQPage` |
 | Blog posts | `Article` or `BlogPosting`, `Person` (author), `BreadcrumbList` |
@@ -89,7 +89,7 @@ Load when § 2 business type detection identifies a specific industry.
 | Products with certs | `Certification` (energy ratings, safety marks) — replaces `EnergyConsumptionDetails` |
 | Products with shipping | `OfferShippingDetails` nested in `Offer` |
 | Category pages | `ItemList`, `BreadcrumbList` |
-| Homepage | `Organization`, `WebSite` (Sitelinks Searchbox) |
+| Homepage | `Organization`, `WebSite` |
 | Buying guides | `Article`, `ItemList` |
 
 ### ProductGroup Example (Variants)

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/keyword-strategy.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/keyword-strategy.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: verified, no change needed — audited for Google-behaviour claims and externally-sourced statistics; contains neither. All numeric values are internal rubric thresholds, which do not decay. Date reflects that audit, not a rewrite. -->
+<!-- 2026-08-23 review: SUPERSEDED by the 2026-08-23 re-review. The earlier pass marked this file 'verified, no change needed' on the basis of a grep for date-bearing and externally-sourced claims. Reading it end to end found: priority-scoring formula divided by 5, capping the maximum at 1.0 and making every tier above P3 unreachable. Scanning is not review. -->
 
 # Keyword Research & Content Strategy Guide
 ## Updated: August 2026
@@ -228,7 +228,11 @@ Quantitative prioritization for content calendar decisions:
 | **Long-term** | High | High | Transactional | Medium — requires authority |
 | **Research** | Low | Low | Informational | Low — good for topic clusters |
 
-**Priority Scoring** (weighted): Score each keyword 1–5 on these factors, then calculate `Σ(Factor Weight × Score) / 5`:
+**Priority Scoring** (weighted): Score each keyword 1–5 on these factors, then calculate `Σ(Factor Weight × Score)`:
+
+The weights sum to 100%, so the weighted sum already lands on the same 1–5 scale as the scores —
+there is no further division. (A previous version divided by 5, which capped the maximum achievable
+score at 1.0 and made every keyword fall into P3 regardless of merit.)
 
 | Factor | Weight |
 |---|---|

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/procedures/19-quality-gates-hard-rules.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/procedures/19-quality-gates-hard-rules.md
@@ -53,5 +53,5 @@ This pattern is adapted from Anthropic's [Evaluator-Optimizer workflow](https://
 
 **Blocking AI crawlers harms GEO** — Blocking OAI-SearchBot/PerplexityBot removes the site from AI search results entirely.
 
-**GPTBot ≠ training only** — Blocking it also limits ChatGPT Search citation. Users who block GPTBot expecting only training-opt-out lose live search visibility.
+**GPTBot is training-only — do not claim otherwise** — OpenAI runs three separate agents: `GPTBot` (model training), `OAI-SearchBot` (ChatGPT Search index), and `ChatGPT-User` (user-triggered fetches). **Blocking one has no effect on the others.** Blocking `GPTBot` does **not** remove a site from ChatGPT Search citations. Never tell a user that opting out of training costs them ChatGPT visibility — that forecloses a legitimate licensing decision on a false premise. The crawler that actually governs ChatGPT Search visibility is `OAI-SearchBot`; blocking *that* does remove the site from ChatGPT answers.
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/schema-types.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/schema-types.md
@@ -372,7 +372,12 @@ Add to homepage Organization schema to strengthen entity signals:
 
 ### Sitelinks Searchbox
 
-Allows users to search within the site directly from Google results. Add to homepage:
+> **Removed from the Search UI in January 2026** — the `WebSite` `SearchAction` no longer renders a
+> search box in results. The markup is still valid and causes no harm, so **do not recommend removing
+> it** (§ 19 rule 10), but do not present it as a live feature or a reason to add `WebSite` schema.
+> `WebSite` remains worth having for site-level entity signals. Retained below for reference.
+
+Formerly allowed users to search within the site directly from Google results. Homepage markup:
 
 ```json
 {

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/site-migration.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/site-migration.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: verified, no change needed — audited for Google-behaviour claims and externally-sourced statistics; contains neither. All numeric values are internal rubric thresholds, which do not decay. Date reflects that audit, not a rewrite. -->
+<!-- 2026-08-23 review: SUPERSEDED by the 2026-08-23 re-review. The earlier pass marked this file 'verified, no change needed' on the basis of a grep for date-bearing and externally-sourced claims. Reading it end to end found: broken script reference (crawl_urls.py), hop-count self-contradiction, and an inline redirect script that reintroduced the SSRF vector closed in v1.10.2. Scanning is not review. -->
 
 # Site Migration SEO Checklist
 ## Updated: August 2026
@@ -24,7 +24,8 @@ A site migration is any change that risks altering how Google crawls, indexes, o
 ### Step 1: Full URL Crawl Baseline
 Capture the full current URL inventory so you have a source of truth for every URL that needs a redirect.
 
-**Tools:** Screaming Frog, Sitebulb, or `scripts/crawl_urls.py`
+**Tools:** Screaming Frog, Sitebulb, or `scripts/site_mapper.py` (sitemap + BFS crawl:
+`python scripts/site_mapper.py URL --max-pages 500 --json`)
 
 **What to capture:**
 - All indexable URLs (HTTP 200, in sitemap, not noindex)
@@ -119,7 +120,7 @@ curl -I https://olddomain.com/old-path/
 # Location: https://newdomain.com/new-path/
 ```
 
-Check redirect chains: `curl -L -I` should resolve in ≤ 2 hops.
+Check redirect chains: `curl -L -I` should resolve in **one hop** — matching the redirect-map rule above and the Common Mistakes table below, both of which require single-hop. Any second hop is a chain to flatten, not an acceptable outcome.
 
 ### Step 2: Submit Updated Sitemap
 - Submit new sitemap to Google Search Console
@@ -203,28 +204,20 @@ Watch Google Search Console → Coverage report for the first 24–48 hours. Loo
 
 ---
 
-## Redirect Map Validation Script
+## Redirect Map Validation
 
-```python
-# Quick redirect validation (run from command line)
-# Usage: python validate_redirects.py migration-map.csv
+Use the shipped checker — it validates each hop against `scripts/url_safety.py` before fetching:
 
-import csv, requests, sys
-
-with open(sys.argv[1]) as f:
-    rows = list(csv.reader(f))
-
-errors = []
-for old_url, expected_new in rows[1:]:
-    r = requests.get(old_url, allow_redirects=True, timeout=10)
-    final = r.url.rstrip('/')
-    expected = expected_new.rstrip('/')
-    if final != expected:
-        errors.append(f"FAIL: {old_url} → {final} (expected {expected})")
-
-if errors:
-    print('\n'.join(errors))
-    sys.exit(1)
-else:
-    print(f"All {len(rows)-1} redirects validated.")
+```bash
+python scripts/redirect_checker.py https://olddomain.com/old-path/ --json
 ```
+
+> **Do not hand-roll this.** An earlier version of this file carried an inline snippet that looped a
+> redirect map through `requests.get(old_url, allow_redirects=True)` with no URL validation. That is
+> the exact SSRF vector closed in `redirect_checker.py` in v1.10.2: a redirect map is attacker-
+> influenced input, and a single `Location:` header pointing at `http://169.254.169.254/` walks the
+> checker into a cloud metadata endpoint. `redirect_checker.py` calls `validate_url()` per hop;
+> a bare `requests` loop does not.
+
+To validate a whole map, feed the checker each source URL and compare against the expected
+destination — do not re-implement the fetch.

--- a/references/analytics-reporting.md
+++ b/references/analytics-reporting.md
@@ -125,7 +125,7 @@ GSC shows CrUX (real user) data, which is what Google uses for rankings:
 
 - **Rich results**: Eligible vs. Valid vs. Error by schema type
 - **Breadcrumbs**: Structured data parsing errors
-- **Sitelinks searchbox**: If applicable
+- ~~**Sitelinks searchbox**~~: retired — the feature was removed from the Search UI in January 2026, so this enhancement report no longer appears
 
 ---
 

--- a/references/cite-domain-rating.md
+++ b/references/cite-domain-rating.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: verified, no change needed — audited for Google-behaviour claims and externally-sourced statistics; contains neither. All numeric values are internal rubric thresholds, which do not decay. Date reflects that audit, not a rewrite. -->
+<!-- 2026-08-23 review: SUPERSEDED by the 2026-08-23 re-review. The earlier pass marked this file 'verified, no change needed' on the basis of a grep for date-bearing and externally-sourced claims. Reading it end to end found: items score 0-10 while grade bands are 0-100 with no normalisation stated — a perfect domain graded 'Poor'. Scanning is not review. -->
 <!-- Source: domain-authority-auditor skill (aaron-he-zhu/cite-domain-rating) -->
 
 # CITE Domain Authority Rating Framework
@@ -21,7 +21,12 @@
 | **Fail** | 0 |
 | **N/A** | Excluded from dimension average |
 
-**CITE Score** = weighted average of all 4 dimensions using domain-type weights below.
+**CITE Score** = weighted average of all 4 dimensions using domain-type weights below, **×10** to put it on the 0–100 band scale.
+
+> **Scale note.** Items score 0/5/10, so a dimension average and the weighted total both land on a
+> **0–10** scale. The grade bands below are **0–100**. Multiply the weighted total by 10 before
+> reading the bands — otherwise a domain passing every item scores 10 and reads as "Poor".
+
 
 **N/A handling**: Same as CORE-EEAT — if >50% of items in a dimension are N/A, mark "Insufficient Data" and redistribute weight.
 

--- a/references/core-eeat-framework.md
+++ b/references/core-eeat-framework.md
@@ -23,7 +23,12 @@
 
 **GEO Score** = average of CORE dimensions (C + O + R + E) / 4
 **SEO Score** = average of EEAT dimensions (Exp + Ept + A + T) / 4
-**Total Score** = weighted average using content-type weights below
+**Total Score** = weighted average using content-type weights below, **×10** to put it on the 0–100 band scale
+
+> **Scale note.** Items score 0/5/10, so a dimension average and the weighted total both land on a
+> **0–10** scale. The grade bands below are **0–100**. Multiply the weighted total by 10 before
+> reading the bands — otherwise a page passing every item scores 10 and reads as "Poor".
+
 
 **N/A handling**: If >50% of items in a dimension are N/A, mark the dimension as "Insufficient Data" and exclude it — redistribute its weight proportionally to remaining dimensions.
 

--- a/references/entity-optimization.md
+++ b/references/entity-optimization.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: verified, no change needed — audited for Google-behaviour claims and externally-sourced statistics; contains neither. All numeric values are internal rubric thresholds, which do not decay. Date reflects that audit, not a rewrite. -->
+<!-- 2026-08-23 review: SUPERSEDED by the 2026-08-23 re-review. The earlier pass marked this file 'verified, no change needed' on the basis of a grep for date-bearing and externally-sourced claims. Reading it end to end found: signal 36 named the training-only crawler; AI Overviews/AI Mode collapsed into one column despite being distinct citation engines (bands rescaled /48 -> /60). Scanning is not review. -->
 <!-- Source: entity-optimizer skill (aaron-he-zhu) -->
 
 # Entity Optimization — Knowledge Graph, Brand Entity & AI Recognition
@@ -38,22 +38,27 @@ For each query × platform combination, score:
 
 ### Results Template
 
-| Query | ChatGPT | Perplexity | Google AI Overview | Claude |
-|---|---|---|---|---|
-| "What is [Entity]?" | X/3 | X/3 | X/3 | X/3 |
-| "Who founded [Entity]?" | X/3 | X/3 | X/3 | X/3 |
-| "How does [Entity] compare to [Competitor]?" | X/3 | X/3 | X/3 | X/3 |
-| "[Entity]'s approach to [Topic]" | X/3 | X/3 | X/3 | X/3 |
-| **Platform Total** | /12 | /12 | /12 | /12 |
+| Query | ChatGPT | Perplexity | Google AI Overviews | Google AI Mode | Claude |
+|---|---|---|---|---|---|
+| "What is [Entity]?" | X/3 | X/3 | X/3 | X/3 | X/3 |
+| "Who founded [Entity]?" | X/3 | X/3 | X/3 | X/3 | X/3 |
+| "How does [Entity] compare to [Competitor]?" | X/3 | X/3 | X/3 | X/3 | X/3 |
+| "[Entity]'s approach to [Topic]" | X/3 | X/3 | X/3 | X/3 | X/3 |
+| **Platform Total** | /12 | /12 | /12 | /12 | /12 |
 
-**Overall Entity Recognition Score**: /48
+**Overall Entity Recognition Score**: /60
+
+**AI Overviews and AI Mode are scored separately on purpose.** They share only 13.7% URL overlap
+(Ahrefs, 540K query pairs), so they are distinct citation engines — an entity can be well recognised
+in one and absent from the other. Collapsing them into a single "Google" column hides exactly the
+gap this test exists to find.
 
 | Score Range | Assessment | Action |
 |---|---|---|
-| 36–48 | Strong recognition | Maintain and refine accuracy |
-| 24–35 | Moderate recognition | Fill specific gaps identified |
-| 12–23 | Weak recognition | Prioritize foundation signals |
-| 0–11 | Not recognized | Full entity building program needed |
+| 45–60 | Strong recognition | Maintain and refine accuracy |
+| 30–44 | Moderate recognition | Fill specific gaps identified |
+| 15–29 | Weak recognition | Prioritize foundation signals |
+| 0–14 | Not recognized | Full entity building program needed |
 
 ---
 
@@ -139,7 +144,7 @@ For each query × platform combination, score:
 | 33 | Entity definition quotable in first paragraph | Clear "X is..." definition in opening of about/homepage | Definition buried or missing |
 | 34 | Factual claims verifiable | Key claims have authoritative sources | Unsourced claims |
 | 35 | Entity name used consistently | Same entity name across all platforms and content | Name variations causing confusion |
-| 36 | Content crawlable by AI systems | AI crawlers (GPTBot, PerplexityBot) allowed in robots.txt | AI crawlers blocked |
+| 36 | Content crawlable by AI systems | The crawlers that govern *recognition* are allowed: `OAI-SearchBot` (ChatGPT Search), `ChatGPT-User` (live fetches), `PerplexityBot`, `ClaudeBot`. `GPTBot` is training-only and does **not** affect signals 28–29 | Search/fetch crawlers blocked |
 | 37 | Fresh information available | Key pages updated within last 6 months | Stale content (12+ months) |
 
 ### Priority 4: Advanced Signals (Nice-to-Have) — Signals 38–47

--- a/references/industry-templates.md
+++ b/references/industry-templates.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: verified, no change needed — audited for Google-behaviour claims and externally-sourced statistics; contains neither. All numeric values are internal rubric thresholds, which do not decay. Date reflects that audit, not a rewrite. -->
+<!-- 2026-08-23 review: SUPERSEDED by the 2026-08-23 re-review. The earlier pass marked this file 'verified, no change needed' on the basis of a grep for date-bearing and externally-sourced claims. Reading it end to end found: recommended WebSite schema *for* the Sitelinks Searchbox, removed from the Search UI in January 2026. Scanning is not review. -->
 
 # Industry-Specific SEO Templates
 
@@ -38,7 +38,7 @@ Load when § 2 business type detection identifies a specific industry.
 
 | Page Type | Schema |
 |---|---|
-| Homepage | `WebApplication` or `SoftwareApplication`, `Organization`, `WebSite` (Sitelinks Searchbox) |
+| Homepage | `WebApplication` or `SoftwareApplication`, `Organization`, `WebSite` |
 | Feature pages | `SoftwareApplication`, `FAQPage` |
 | Pricing | `Offer`, `FAQPage` |
 | Blog posts | `Article` or `BlogPosting`, `Person` (author), `BreadcrumbList` |
@@ -89,7 +89,7 @@ Load when § 2 business type detection identifies a specific industry.
 | Products with certs | `Certification` (energy ratings, safety marks) — replaces `EnergyConsumptionDetails` |
 | Products with shipping | `OfferShippingDetails` nested in `Offer` |
 | Category pages | `ItemList`, `BreadcrumbList` |
-| Homepage | `Organization`, `WebSite` (Sitelinks Searchbox) |
+| Homepage | `Organization`, `WebSite` |
 | Buying guides | `Article`, `ItemList` |
 
 ### ProductGroup Example (Variants)

--- a/references/keyword-strategy.md
+++ b/references/keyword-strategy.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: verified, no change needed — audited for Google-behaviour claims and externally-sourced statistics; contains neither. All numeric values are internal rubric thresholds, which do not decay. Date reflects that audit, not a rewrite. -->
+<!-- 2026-08-23 review: SUPERSEDED by the 2026-08-23 re-review. The earlier pass marked this file 'verified, no change needed' on the basis of a grep for date-bearing and externally-sourced claims. Reading it end to end found: priority-scoring formula divided by 5, capping the maximum at 1.0 and making every tier above P3 unreachable. Scanning is not review. -->
 
 # Keyword Research & Content Strategy Guide
 ## Updated: August 2026
@@ -228,7 +228,11 @@ Quantitative prioritization for content calendar decisions:
 | **Long-term** | High | High | Transactional | Medium — requires authority |
 | **Research** | Low | Low | Informational | Low — good for topic clusters |
 
-**Priority Scoring** (weighted): Score each keyword 1–5 on these factors, then calculate `Σ(Factor Weight × Score) / 5`:
+**Priority Scoring** (weighted): Score each keyword 1–5 on these factors, then calculate `Σ(Factor Weight × Score)`:
+
+The weights sum to 100%, so the weighted sum already lands on the same 1–5 scale as the scores —
+there is no further division. (A previous version divided by 5, which capped the maximum achievable
+score at 1.0 and made every keyword fall into P3 regardless of merit.)
 
 | Factor | Weight |
 |---|---|

--- a/references/procedures/19-quality-gates-hard-rules.md
+++ b/references/procedures/19-quality-gates-hard-rules.md
@@ -53,5 +53,5 @@ This pattern is adapted from Anthropic's [Evaluator-Optimizer workflow](https://
 
 **Blocking AI crawlers harms GEO** — Blocking OAI-SearchBot/PerplexityBot removes the site from AI search results entirely.
 
-**GPTBot ≠ training only** — Blocking it also limits ChatGPT Search citation. Users who block GPTBot expecting only training-opt-out lose live search visibility.
+**GPTBot is training-only — do not claim otherwise** — OpenAI runs three separate agents: `GPTBot` (model training), `OAI-SearchBot` (ChatGPT Search index), and `ChatGPT-User` (user-triggered fetches). **Blocking one has no effect on the others.** Blocking `GPTBot` does **not** remove a site from ChatGPT Search citations. Never tell a user that opting out of training costs them ChatGPT visibility — that forecloses a legitimate licensing decision on a false premise. The crawler that actually governs ChatGPT Search visibility is `OAI-SearchBot`; blocking *that* does remove the site from ChatGPT answers.
 

--- a/references/schema-types.md
+++ b/references/schema-types.md
@@ -372,7 +372,12 @@ Add to homepage Organization schema to strengthen entity signals:
 
 ### Sitelinks Searchbox
 
-Allows users to search within the site directly from Google results. Add to homepage:
+> **Removed from the Search UI in January 2026** — the `WebSite` `SearchAction` no longer renders a
+> search box in results. The markup is still valid and causes no harm, so **do not recommend removing
+> it** (§ 19 rule 10), but do not present it as a live feature or a reason to add `WebSite` schema.
+> `WebSite` remains worth having for site-level entity signals. Retained below for reference.
+
+Formerly allowed users to search within the site directly from Google results. Homepage markup:
 
 ```json
 {

--- a/references/site-migration.md
+++ b/references/site-migration.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: verified, no change needed — audited for Google-behaviour claims and externally-sourced statistics; contains neither. All numeric values are internal rubric thresholds, which do not decay. Date reflects that audit, not a rewrite. -->
+<!-- 2026-08-23 review: SUPERSEDED by the 2026-08-23 re-review. The earlier pass marked this file 'verified, no change needed' on the basis of a grep for date-bearing and externally-sourced claims. Reading it end to end found: broken script reference (crawl_urls.py), hop-count self-contradiction, and an inline redirect script that reintroduced the SSRF vector closed in v1.10.2. Scanning is not review. -->
 
 # Site Migration SEO Checklist
 ## Updated: August 2026
@@ -24,7 +24,8 @@ A site migration is any change that risks altering how Google crawls, indexes, o
 ### Step 1: Full URL Crawl Baseline
 Capture the full current URL inventory so you have a source of truth for every URL that needs a redirect.
 
-**Tools:** Screaming Frog, Sitebulb, or `scripts/crawl_urls.py`
+**Tools:** Screaming Frog, Sitebulb, or `scripts/site_mapper.py` (sitemap + BFS crawl:
+`python scripts/site_mapper.py URL --max-pages 500 --json`)
 
 **What to capture:**
 - All indexable URLs (HTTP 200, in sitemap, not noindex)
@@ -119,7 +120,7 @@ curl -I https://olddomain.com/old-path/
 # Location: https://newdomain.com/new-path/
 ```
 
-Check redirect chains: `curl -L -I` should resolve in ≤ 2 hops.
+Check redirect chains: `curl -L -I` should resolve in **one hop** — matching the redirect-map rule above and the Common Mistakes table below, both of which require single-hop. Any second hop is a chain to flatten, not an acceptable outcome.
 
 ### Step 2: Submit Updated Sitemap
 - Submit new sitemap to Google Search Console
@@ -203,28 +204,20 @@ Watch Google Search Console → Coverage report for the first 24–48 hours. Loo
 
 ---
 
-## Redirect Map Validation Script
+## Redirect Map Validation
 
-```python
-# Quick redirect validation (run from command line)
-# Usage: python validate_redirects.py migration-map.csv
+Use the shipped checker — it validates each hop against `scripts/url_safety.py` before fetching:
 
-import csv, requests, sys
-
-with open(sys.argv[1]) as f:
-    rows = list(csv.reader(f))
-
-errors = []
-for old_url, expected_new in rows[1:]:
-    r = requests.get(old_url, allow_redirects=True, timeout=10)
-    final = r.url.rstrip('/')
-    expected = expected_new.rstrip('/')
-    if final != expected:
-        errors.append(f"FAIL: {old_url} → {final} (expected {expected})")
-
-if errors:
-    print('\n'.join(errors))
-    sys.exit(1)
-else:
-    print(f"All {len(rows)-1} redirects validated.")
+```bash
+python scripts/redirect_checker.py https://olddomain.com/old-path/ --json
 ```
+
+> **Do not hand-roll this.** An earlier version of this file carried an inline snippet that looped a
+> redirect map through `requests.get(old_url, allow_redirects=True)` with no URL validation. That is
+> the exact SSRF vector closed in `redirect_checker.py` in v1.10.2: a redirect map is attacker-
+> influenced input, and a single `Location:` header pointing at `http://169.254.169.254/` walks the
+> checker into a cloud metadata endpoint. `redirect_checker.py` calls `validate_url()` per hop;
+> a bare `requests` loop does not.
+
+To validate a whole map, feed the checker each source URL and compare against the expected
+destination — do not re-implement the fetch.

--- a/tests/test_crawler_claims.py
+++ b/tests/test_crawler_claims.py
@@ -1,0 +1,85 @@
+"""OpenAI's three crawlers must not be conflated.
+
+OpenAI runs three separate agents with independent robots.txt controls:
+
+  * ``GPTBot``        -- model training
+  * ``OAI-SearchBot`` -- the ChatGPT Search index
+  * ``ChatGPT-User``  -- user-triggered live fetches
+
+Blocking one has no effect on the others. The repo carried the opposite claim as
+a **§ 19 hard rule** -- "GPTBot ≠ training only. Blocking it also limits ChatGPT
+Search citation. Users who block GPTBot expecting only training-opt-out lose live
+search visibility" -- while `04-technical-seo.md` stated the correct distinction
+a few files away.
+
+That is not a cosmetic inconsistency. A site owner choosing to opt out of model
+training while keeping search visibility is making a real licensing decision, and
+the rule told them it was impossible. Guidance that forecloses a legitimate choice
+on a false premise is worse than no guidance.
+
+It survived because it lived in the *myths* section -- the place a reader goes
+specifically to have misconceptions corrected.
+"""
+
+import os
+import re
+
+import pytest
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+PLUGIN = os.path.join(ROOT, "plugins", "ultimate-seo-geo", "skills", "ultimate-seo-geo")
+TREES = [("root", ROOT), ("plugin", PLUGIN)]
+
+# Files that make crawler claims. Kept explicit rather than globbed so a new file
+# making the same mistake is a deliberate addition here, not a silent pass.
+CLAIM_FILES = [
+    "AGENTS.md",
+    os.path.join("references", "ai-search-geo.md"),
+    os.path.join("references", "entity-optimization.md"),
+    os.path.join("references", "technical-checklist.md"),
+    os.path.join("references", "procedures", "04-technical-seo.md"),
+    os.path.join("references", "procedures", "19-quality-gates-hard-rules.md"),
+]
+
+# Phrasings that assert blocking GPTBot costs ChatGPT Search visibility.
+FALSE_CLAIMS = [
+    r"GPTBot\s*(?:≠|!=|is not|isn'?t)\s*training[- ]only",
+    r"blocking\s+(?:it|GPTBot)[^.]{0,60}\b(?:also\s+)?limits?\s+ChatGPT\s+Search",
+    r"block\w*\s+GPTBot[^.]{0,80}lose\s+(?:live\s+)?search\s+visibility",
+]
+
+
+def _read(tree, rel):
+    with open(os.path.join(tree, rel), encoding="utf-8") as fh:
+        return fh.read()
+
+
+@pytest.mark.parametrize("tree_name,tree", TREES)
+@pytest.mark.parametrize("rel", CLAIM_FILES)
+def test_no_false_gptbot_search_claim(tree_name, tree, rel):
+    """Nothing may claim that blocking GPTBot costs ChatGPT Search citations."""
+    path = os.path.join(tree, rel)
+    if not os.path.isfile(path):
+        pytest.skip(f"{tree_name}/{rel} not present")
+    text = _read(tree, rel)
+    hits = [p for p in FALSE_CLAIMS if re.search(p, text, re.I)]
+    assert not hits, (
+        f"{tree_name}/{rel} claims blocking GPTBot affects ChatGPT Search citations. "
+        f"It does not -- GPTBot is training-only; OAI-SearchBot governs ChatGPT Search and "
+        f"ChatGPT-User handles live fetches, and the three are independent. Matched: {hits}"
+    )
+
+
+@pytest.mark.parametrize("tree_name,tree", TREES)
+def test_hard_rule_names_the_search_crawler(tree_name, tree):
+    """The § 19 rule must name OAI-SearchBot, not just warn about GPTBot.
+
+    Naming the wrong crawler is how the original bug did damage: a reader following
+    it would allow GPTBot for a benefit it does not provide, and could still be
+    invisible in ChatGPT Search because OAI-SearchBot was blocked.
+    """
+    text = _read(tree, os.path.join("references", "procedures", "19-quality-gates-hard-rules.md"))
+    assert "OAI-SearchBot" in text, (
+        f"{tree_name}/19-quality-gates-hard-rules.md discusses AI crawler blocking without naming "
+        f"OAI-SearchBot, the crawler that actually governs ChatGPT Search visibility."
+    )


### PR DESCRIPTION
The earlier pass marked these five *"verified, no change needed"* on the basis of a grep for date-bearing and externally-sourced claims. Reading them end to end found defects in **all five**, plus three contradictions they exposed elsewhere.

The review labels are corrected in place to say what that pass actually did. **Scanning is not review.**

## The serious one: a §19 hard rule was factually wrong

> "GPTBot ≠ training only. Blocking it also limits ChatGPT Search citation. Users who block GPTBot expecting only training-opt-out lose live search visibility."

OpenAI runs three independent agents — `GPTBot` (training), `OAI-SearchBot` (ChatGPT Search index), `ChatGPT-User` (live fetches). **Blocking one has no effect on the others.** `04-technical-seo.md` stated this correctly a few files away.

The rule told site owners that opting out of model training costs them ChatGPT visibility — **foreclosing a real licensing decision on a false premise**. Guidance that removes a legitimate choice on bad facts is worse than no guidance. It survived in the *myths* section, which is where a reader goes specifically to have misconceptions corrected.

`tests/test_crawler_claims.py` bars the phrasing across both trees and requires the §19 rule to name `OAI-SearchBot`. Validated by reintroducing the original wording.

## Two scoring frameworks couldn't produce their own top grades

**`keyword-strategy.md`** — `Σ(Factor Weight × Score) / 5`, weights summing to 100%, scores 1–5. The weighted sum already lands on 1–5; the `÷5` capped the maximum at **1.00**, which its own table classifies as *"P3 — track but don't prioritize."* A perfect keyword scored lowest.

**`cite-domain-rating.md` + `core-eeat-framework.md`** — items score 0/5/10 → dimension averages on **0–10**, grade bands on **0–100**, no normalisation stated. A page passing every item scores 10 and reads *"0–39 Poor."*

## An SSRF vector this repo had already closed

`site-migration.md` shipped an inline redirect validator looping a migration map through `requests.get(old_url, allow_redirects=True)` with no URL validation — exactly what `validate_url()` was added to `redirect_checker.py` to prevent in **v1.10.2**. A redirect map is attacker-influenced input; one `Location:` header pointing at `169.254.169.254` walks the checker into a cloud metadata endpoint.

Replaced with the shipped checker. Also: `scripts/crawl_urls.py` doesn't exist (→ `site_mapper.py`), and "resolve in ≤ 2 hops" contradicted the same file's redirect-map rule *and* its Common Mistakes table, both requiring single-hop.

## Also fixed

- **`entity-optimization.md` signal 36** measured AI *recognition* by checking `GPTBot`, which has no bearing on it. Its resolution test also collapsed AI Overviews and AI Mode into one column, though this repo documents them as distinct engines sharing 13.7% overlap — hiding exactly the gap the test exists to find. Split; bands rescaled /48 → /60 with proportions preserved (75/50/25%).
- **Sitelinks Searchbox** presented as live in three files while `schema-types.md` records it removed from the Search UI in January 2026. Corrected without recommending markup removal, per §19 rule 10.

## Verification

- `pytest tests/` — **154 passed** (was 140)
- New crawler guard validated by reintroducing the original false wording — fails in both trees
- Entity band rescale verified to preserve the original percentage boundaries exactly
- Keyword formula verified numerically: `÷5` made P0–P2 unreachable; without it the range is exactly 1.0–5.0
- `check-plugin-sync.py` green at 1.12.2; `AGENTS.md` 30,356 B, still under the Codex cap

## Note

This vindicates the caveat raised when #24 shipped: the five "no change needed" verdicts were weaker than the eight "corrected" ones, because scanning can't see a broken formula, a wrong crawler, or a security regression. None of these nine defects contained a date or a statistic, which is why the grep found nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)