### PR TITLE
fix: run the arithmetic on every scoring rubric

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,7 +200,7 @@ First-Principle Observation: [the raw observable fact that triggered this findin
 Dependency: [what other findings this blocks, enables, or depends on]
 ```
 
-**Scoring:** `base_score = (positive_signals / (positive_signals + deficit_signals)) × 100`. Deduct: Critical −15 pts, Warning −5 pts.
+**Scoring:** `base_score = (positive_signals / (positive_signals + deficit_signals)) × 100`. Deduct by finding severity: **Critical −15, High −8, Medium −3, Low −1** (matches § 19 rule 3, which validates the score against this schedule).
 
 ### Audit Output Template
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@
 
 ### Fixed
 
+Ran the arithmetic on every scoring rubric in the repo, after three of them were found unable to
+produce their own top grades. **All 24 weight columns across 13 files sum to 100%** — no weight bugs.
+The failures were all in aggregation and in worked examples.
+
+- **The canonical GEO worked example was wrong twice** (`audit-output-example.md`) — its headline
+  said 41/100 while its own five rows compute to 42.5, and its Technical Accessibility row was docked
+  to 70 with *"no llms.txt ❌"* given as a reason. That is a **fourth copy** of the llms.txt scoring
+  contradiction, in the one place that propagates furthest: worked examples get copied verbatim.
+  Corrected to 90 on that dimension and 47/100 overall.
+
+- **The Health Score example demonstrated a procedure and then did not follow it** — it computed
+  `base=61, Critical −15×0, Warning −5×2 = 51`, then reported **61**, the pre-deduction base, via an
+  unexplained *"→ adjusted 61."* The deductions were performed and silently discarded. Recomputed
+  against the example's own findings (2 High + 1 Quick Win): 61 − 16 − 1 = **44**.
+
+- **Three different deduction schedules for one score** — `AGENTS.md` and `02-full-site-audit.md`
+  said *Critical −15, Warning −5*; `19-quality-gates-hard-rules.md` rule 3, which **validates** the
+  Health Score, said *Critical −15, High −8, Medium −3, Low −1*. The gate checked against a schedule
+  the instructions did not use, and "Warning" is not a severity the audit output template emits at
+  all. All three now carry the four-severity schedule, including the chain-of-thought template.
+
+- **The GEO Score and `content-eeat.md` stated weights but no aggregation formula** — the same
+  ambiguity that let CITE and CORE-EEAT grade a perfect score as "Poor". Both now state: score each
+  dimension 0–100, `Σ(weight × score)`, no further division.
+
+- **Verified correct, no change**: `eeat-framework.md` (states the formula and carries a worked
+  example that computes exactly), `backlink-quality.md` (*"each factor scored 0–100 independently,
+  then weighted"*). Reported because a negative result on a rubric that was checked is worth
+  distinguishing from one that was not.
+
+### Added
+
+- **`tests/test_scoring_rubrics.py`** — 54 tests. Asserts every weight column in every reference file
+  sums to 100%, that the GEO worked example equals its own rows, that no worked example deducts for a
+  missing llms.txt, and that the Health Score example applies the deduction schedule it prints.
+  Validated by reintroducing each of the three example bugs in turn. None of these defects contained
+  a date or an out-of-range value, which is why every previous sweep missed them — this suite runs
+  the maths instead of reading for suspicious-looking numbers.
+
 Re-review of the five reference files that v1.12.2's predecessor marked *"verified, no change
 needed."* That verdict came from a grep for date-bearing and externally-sourced claims. Reading the
 files end to end found defects in **all five**, plus three contradictions they exposed elsewhere.

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
@@ -200,7 +200,7 @@ First-Principle Observation: [the raw observable fact that triggered this findin
 Dependency: [what other findings this blocks, enables, or depends on]
 ```
 
-**Scoring:** `base_score = (positive_signals / (positive_signals + deficit_signals)) × 100`. Deduct: Critical −15 pts, Warning −5 pts.
+**Scoring:** `base_score = (positive_signals / (positive_signals + deficit_signals)) × 100`. Deduct by finding severity: **Critical −15, High −8, Medium −3, Low −1** (matches § 19 rule 3, which validates the score against this schedule).
 
 ### Audit Output Template
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/ai-search-geo.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/ai-search-geo.md
@@ -33,6 +33,9 @@
 | Technical Accessibility | 20% | AI crawlers allowed in robots.txt, server-side rendering, key content present in raw HTML |
 | Multi-Modal Content | 15% | Text + images + video + structured data (78% of cited sources combine these) |
 
+**Scoring formula**: score each dimension **0–100**, then `Σ(dimension weight × dimension score)`. Weights sum to 100%, so the result is already on the 0–100 scale — no further division. (Worked example: `references/audit-output-example.md` § Example 3.)
+
+
 ### Platform-to-Dimension Mapping
 
 Different AI platforms prioritize different GEO dimensions. Use this matrix to allocate optimization effort by platform importance for your strategy.

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/audit-output-example.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/audit-output-example.md
@@ -12,8 +12,8 @@
 # SEO Audit Report — greenleaf.io
 Date: 2026-03-15 | Business Type: SaaS | Audited Pages: 8 | Confidence: Medium
 
-## SEO Health Score: 61/100
-positive_signals=14, deficit_signals=9, base=61, Critical −15×0, Warning −5×2 = 51 → adjusted 61
+## SEO Health Score: 44/100
+positive_signals=14, deficit_signals=9, base=61; deductions: Critical −15×0, High −8×2, Medium −3×0, Low −1×1 = 44
 
 ## 🟠 High Priority
 
@@ -105,14 +105,14 @@ Date: 2026-03-22 | Focus: AI Search Citation | Pages Reviewed: 6
 | 4 | Named author with credentials? | ❌ No — blog posts have no author bylines |
 | 5 | Brand on YouTube or Reddit? | ❌ No presence on either platform |
 
-## GEO Score: 41/100
+## GEO Score: 47/100
 
 | Dimension | Weight | Score | Notes |
 |-----------|--------|-------|-------|
 | Citability | 25% | 35 | Key answers buried; no self-contained 134–167 word blocks |
 | Structural Readability | 20% | 60 | Clean H1→H2 hierarchy; some question headings |
 | Authority & Brand Signals | 20% | 20 | No author bios, no Wikipedia/Reddit/YouTube presence |
-| Technical Accessibility | 20% | 70 | SSR ✅, AI crawlers ✅, no llms.txt ❌ |
+| Technical Accessibility | 20% | 90 | SSR ✅, AI crawlers ✅, key content in raw HTML ✅ |
 | Multi-Modal Content | 15% | 25 | Text-only; no video, limited images |
 
 ## 🔴 Critical

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/content-eeat.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/content-eeat.md
@@ -18,6 +18,9 @@
 | AI citation readiness | 10% | Passage structure, answer-first format |
 | Freshness | 10% | Publication date, last-updated, recency |
 
+**Scoring formula**: score each category **0–100**, then `Σ(category weight × category score)`. Weights sum to 100%, so the result lands on the 0–100 scale used by the Content Audit Scoring Matrix below — no further division.
+
+
 ---
 
 ## Word Count Floors

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/procedures/02-full-site-audit.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/procedures/02-full-site-audit.md
@@ -92,7 +92,7 @@ Dependency: [what other findings this blocks, enables, or depends on — use fin
 - **Likely**: Strong inference from partial data (2–3 signals)
 - **Hypothesis**: Pattern-based assumption; limited page access
 
-**Scoring formula:** `base_score = (positive_signals / (positive_signals + deficit_signals)) × 100`. Deduct: Critical −15 pts, Warning −5 pts.
+**Scoring formula:** `base_score = (positive_signals / (positive_signals + deficit_signals)) × 100`. Deduct by finding severity: **Critical −15, High −8, Medium −3, Low −1** (matches § 19 rule 3, which validates the score against this schedule).
 
 ### Audit Output Format
 
@@ -103,7 +103,7 @@ Use this exact template:
 Date: [date] | Business Type: [type] | Audited Pages: [N] | Confidence: High/Medium/Low
 
 ## SEO Health Score: XX/100
-[chain-of-thought: positive_signals=N, deficit_signals=N, base=XX, Critical −15×N, Warning −5×N = final]
+[chain-of-thought: positive_signals=N, deficit_signals=N, base=XX, Critical −15×N, High −8×N, Medium −3×N, Low −1×N = final]
 
 | Category | Score | Status |
 |---|---|---|

--- a/references/ai-search-geo.md
+++ b/references/ai-search-geo.md
@@ -33,6 +33,9 @@
 | Technical Accessibility | 20% | AI crawlers allowed in robots.txt, server-side rendering, key content present in raw HTML |
 | Multi-Modal Content | 15% | Text + images + video + structured data (78% of cited sources combine these) |
 
+**Scoring formula**: score each dimension **0–100**, then `Σ(dimension weight × dimension score)`. Weights sum to 100%, so the result is already on the 0–100 scale — no further division. (Worked example: `references/audit-output-example.md` § Example 3.)
+
+
 ### Platform-to-Dimension Mapping
 
 Different AI platforms prioritize different GEO dimensions. Use this matrix to allocate optimization effort by platform importance for your strategy.

--- a/references/audit-output-example.md
+++ b/references/audit-output-example.md
@@ -12,8 +12,8 @@
 # SEO Audit Report — greenleaf.io
 Date: 2026-03-15 | Business Type: SaaS | Audited Pages: 8 | Confidence: Medium
 
-## SEO Health Score: 61/100
-positive_signals=14, deficit_signals=9, base=61, Critical −15×0, Warning −5×2 = 51 → adjusted 61
+## SEO Health Score: 44/100
+positive_signals=14, deficit_signals=9, base=61; deductions: Critical −15×0, High −8×2, Medium −3×0, Low −1×1 = 44
 
 ## 🟠 High Priority
 
@@ -105,14 +105,14 @@ Date: 2026-03-22 | Focus: AI Search Citation | Pages Reviewed: 6
 | 4 | Named author with credentials? | ❌ No — blog posts have no author bylines |
 | 5 | Brand on YouTube or Reddit? | ❌ No presence on either platform |
 
-## GEO Score: 41/100
+## GEO Score: 47/100
 
 | Dimension | Weight | Score | Notes |
 |-----------|--------|-------|-------|
 | Citability | 25% | 35 | Key answers buried; no self-contained 134–167 word blocks |
 | Structural Readability | 20% | 60 | Clean H1→H2 hierarchy; some question headings |
 | Authority & Brand Signals | 20% | 20 | No author bios, no Wikipedia/Reddit/YouTube presence |
-| Technical Accessibility | 20% | 70 | SSR ✅, AI crawlers ✅, no llms.txt ❌ |
+| Technical Accessibility | 20% | 90 | SSR ✅, AI crawlers ✅, key content in raw HTML ✅ |
 | Multi-Modal Content | 15% | 25 | Text-only; no video, limited images |
 
 ## 🔴 Critical

--- a/references/content-eeat.md
+++ b/references/content-eeat.md
@@ -18,6 +18,9 @@
 | AI citation readiness | 10% | Passage structure, answer-first format |
 | Freshness | 10% | Publication date, last-updated, recency |
 
+**Scoring formula**: score each category **0–100**, then `Σ(category weight × category score)`. Weights sum to 100%, so the result lands on the 0–100 scale used by the Content Audit Scoring Matrix below — no further division.
+
+
 ---
 
 ## Word Count Floors

--- a/references/procedures/02-full-site-audit.md
+++ b/references/procedures/02-full-site-audit.md
@@ -92,7 +92,7 @@ Dependency: [what other findings this blocks, enables, or depends on — use fin
 - **Likely**: Strong inference from partial data (2–3 signals)
 - **Hypothesis**: Pattern-based assumption; limited page access
 
-**Scoring formula:** `base_score = (positive_signals / (positive_signals + deficit_signals)) × 100`. Deduct: Critical −15 pts, Warning −5 pts.
+**Scoring formula:** `base_score = (positive_signals / (positive_signals + deficit_signals)) × 100`. Deduct by finding severity: **Critical −15, High −8, Medium −3, Low −1** (matches § 19 rule 3, which validates the score against this schedule).
 
 ### Audit Output Format
 
@@ -103,7 +103,7 @@ Use this exact template:
 Date: [date] | Business Type: [type] | Audited Pages: [N] | Confidence: High/Medium/Low
 
 ## SEO Health Score: XX/100
-[chain-of-thought: positive_signals=N, deficit_signals=N, base=XX, Critical −15×N, Warning −5×N = final]
+[chain-of-thought: positive_signals=N, deficit_signals=N, base=XX, Critical −15×N, High −8×N, Medium −3×N, Low −1×N = final]
 
 | Category | Score | Status |
 |---|---|---|

--- a/tests/test_scoring_rubrics.py
+++ b/tests/test_scoring_rubrics.py
@@ -1,0 +1,160 @@
+"""Every scoring rubric's arithmetic must land inside its own bands.
+
+Three rubrics shipped with maths that could not produce their own top grades:
+
+  * `keyword-strategy.md` divided the weighted sum by 5, capping the maximum at
+    1.00 -- which its own table calls "P3, track but don't prioritize".
+  * `cite-domain-rating.md` and `core-eeat-framework.md` scored items 0/5/10 and
+    banded grades 0-100 with no normalisation stated, so a perfect score read
+    "Poor".
+
+None of these contained a date or an out-of-range number, so the freshness sweep
+that cleared those files saw nothing. They are only visible if you run the maths.
+
+This file runs the maths. It checks the two mechanical properties that hold for
+every weighted rubric in the repo:
+
+  1. Weight columns sum to 100%. A column that does not is either missing a row
+     or double-counting one.
+  2. Worked examples agree with their own stated weights. An example is what a
+     reader copies, so an example that contradicts its rubric propagates further
+     than the rubric does.
+"""
+
+import glob
+import os
+import re
+
+import pytest
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+
+PCT = re.compile(r"(\d{1,3})\s*%")
+
+
+def _tables(text):
+    """Yield (header_cells, row_cells, line_no) for each markdown table."""
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        is_row = lines[i].strip().startswith("|")
+        has_sep = i + 1 < len(lines) and re.match(r"^\s*\|[\s:|-]+\|\s*$", lines[i + 1])
+        if is_row and has_sep:
+            hdr = [c.strip() for c in lines[i].strip().strip("|").split("|")]
+            rows, j = [], i + 2
+            while j < len(lines) and lines[j].strip().startswith("|"):
+                rows.append([c.strip() for c in lines[j].strip().strip("|").split("|")])
+                j += 1
+            yield hdr, rows, i + 1
+            i = j
+        else:
+            i += 1
+
+
+def _weight_columns(text):
+    """Yield (column_name, line_no, [percentages]) for columns that are all percentages."""
+    for hdr, rows, ln in _tables(text):
+        if not rows:
+            continue
+        ncol = max(len(r) for r in rows)
+        for c in range(ncol):
+            filled = [r[c].replace("**", "").strip() for r in rows if c < len(r) and r[c].strip()]
+            vals = [int(m.group(1)) for m in (PCT.fullmatch(v) for v in filled) if m]
+            # Every filled cell is a bare percentage, and enough of them to be a rubric.
+            if len(vals) >= 3 and len(vals) == len(filled):
+                yield (hdr[c] if c < len(hdr) else f"col{c}"), ln, vals
+
+
+REFERENCE_FILES = sorted(
+    glob.glob(os.path.join(ROOT, "references", "**", "*.md"), recursive=True)
+) + [os.path.join(ROOT, "AGENTS.md")]
+
+
+@pytest.mark.parametrize("path", REFERENCE_FILES, ids=lambda p: os.path.basename(p))
+def test_weight_columns_sum_to_100(path):
+    """A weight column that does not total 100% cannot produce a score in its bands."""
+    with open(path, encoding="utf-8") as fh:
+        text = fh.read()
+    bad = [
+        (name, ln, vals, sum(vals))
+        for name, ln, vals in _weight_columns(text)
+        if sum(vals) != 100
+    ]
+    assert not bad, (
+        f"{os.path.relpath(path, ROOT)}: weight column(s) do not sum to 100%: "
+        + "; ".join(f"'{n}' at line {ln} = {s}% {v}" for n, ln, v, s in bad)
+    )
+
+
+def test_geo_worked_example_matches_its_weights():
+    """The GEO example in audit-output-example.md must equal its own arithmetic.
+
+    This example carried a Technical Accessibility score docked for a missing
+    llms.txt -- a fourth copy of the scoring contradiction -- and a headline that
+    disagreed with its own rows by 1.5 points.
+    """
+    path = os.path.join(ROOT, "references", "audit-output-example.md")
+    with open(path, encoding="utf-8") as fh:
+        text = fh.read()
+
+    m = re.search(r"## GEO Score: (\d+)/100", text)
+    assert m, "GEO worked example not found"
+    stated = int(m.group(1))
+
+    section = text[m.end():]
+    rows = re.findall(r"^\|\s*([\w &-]+?)\s*\|\s*(\d{1,3})%\s*\|\s*(\d{1,3})\s*\|", section, re.M)
+    assert len(rows) >= 5, f"expected the 5 GEO dimension rows, found {len(rows)}"
+
+    weights = [int(w) for _, w, _ in rows]
+    assert sum(weights) == 100, f"GEO example weights sum to {sum(weights)}%, not 100%"
+
+    computed = sum(int(w) * int(s) for _, w, s in rows) / 100
+    assert abs(computed - stated) < 1, (
+        f"GEO worked example states {stated}/100 but its own rows compute to {computed:.2f}. "
+        f"A reader copying this example inherits the discrepancy."
+    )
+
+
+def test_geo_example_does_not_dock_for_llms_txt():
+    """Google ignores llms.txt, so no worked example may deduct for its absence."""
+    path = os.path.join(ROOT, "references", "audit-output-example.md")
+    with open(path, encoding="utf-8") as fh:
+        text = fh.read()
+    offenders = [
+        line for line in text.splitlines()
+        if re.search(r"no llms\.txt|llms\.txt\s*❌", line, re.I)
+    ]
+    assert not offenders, (
+        f"audit-output-example.md deducts for a missing llms.txt, which Google ignores "
+        f"(June 2026). Worked examples are copied verbatim.\nOffending: {offenders}"
+    )
+
+
+def test_health_score_example_matches_its_own_deductions():
+    """The Health Score example must apply the deduction schedule it prints.
+
+    It previously computed 51 and then reported 61 -- the pre-deduction base --
+    with an unexplained "adjusted" step, so it demonstrated a procedure and then
+    did not follow it.
+    """
+    path = os.path.join(ROOT, "references", "audit-output-example.md")
+    with open(path, encoding="utf-8") as fh:
+        text = fh.read()
+
+    m = re.search(
+        r"## SEO Health Score: (\d+)/100\s*\n"
+        r"positive_signals=(\d+), deficit_signals=(\d+), base=(\d+);?\s*"
+        r"(?:deductions:)?\s*Critical −15×(\d+), High −8×(\d+), Medium −3×(\d+), Low −1×(\d+)\s*=\s*(\d+)",
+        text,
+    )
+    assert m, "Health Score worked example not found in the expected four-severity form"
+    stated, pos, deficit, base, crit, high, med, low, final = (int(g) for g in m.groups())
+
+    assert round(pos / (pos + deficit) * 100) == base, (
+        f"base_score should be {pos}/({pos}+{deficit})×100 = {pos/(pos+deficit)*100:.1f}, example says {base}"
+    )
+    expected = base - 15 * crit - 8 * high - 3 * med - 1 * low
+    assert expected == final == stated, (
+        f"Health Score example: base {base} minus its own deductions = {expected}, "
+        f"but the line ends at {final} and the headline says {stated}."
+    )


### PR DESCRIPTION
After three rubrics were found unable to produce their own top grades, I checked the maths on all of them.

**All 24 weight columns across 13 files sum to 100%** — no weight bugs. Every failure was in *aggregation* or in *worked examples*.

## The worked examples were the worst of it

**The canonical GEO example was wrong twice.** Its headline said `41/100` while its own five rows compute to **42.5**. And its Technical Accessibility row was docked to 70 with *"no llms.txt ❌"* given as a reason — a **fourth copy** of the llms.txt scoring contradiction, in the one place that propagates furthest. Worked examples get copied verbatim; a rubric gets paraphrased.

**The Health Score example demonstrated a procedure and then didn't follow it:**

```
positive_signals=14, deficit_signals=9, base=61, Critical −15×0, Warning −5×2 = 51 → adjusted 61
```

It computes 51, then reports **61** — the pre-deduction base — via an unexplained "adjusted". The deductions were performed and silently discarded. Recomputed against the example's own findings (2 High + 1 Quick Win): 61 − 16 − 1 = **44**.

## Three deduction schedules for one score

| Source | Schedule |
|---|---|
| `AGENTS.md`, `02-full-site-audit.md` | Critical −15, **Warning −5** |
| `19-quality-gates-hard-rules.md` rule 3 — which **validates** the score | Critical −15, High −8, Medium −3, Low −1 |

The quality gate checked the Health Score against a schedule the instructions didn't use — and "Warning" isn't a severity the audit output template emits at all. All three now carry the four-severity schedule, including the chain-of-thought template.

## Missing aggregation formulas

The **GEO Score** and **`content-eeat.md`** stated weights but never said how to combine them — the same ambiguity that let CITE and CORE-EEAT grade a perfect score as "Poor". Both now state: score each dimension 0–100, `Σ(weight × score)`, no further division.

## Verified correct, unchanged

- **`eeat-framework.md`** — states its formula *and* carries a worked example that computes exactly (verified: 55.75 → 56).
- **`backlink-quality.md`** — *"each factor scored 0–100 independently, then weighted."*

Reported explicitly because a rubric that was checked and passed is worth distinguishing from one that was never checked. That distinction is what the last two rounds turned on.

## Verification

- `pytest tests/` — **208 passed** (was 154)
- `tests/test_scoring_rubrics.py` — 54 tests: every weight column sums to 100%, the GEO example equals its own rows, no worked example deducts for llms.txt, the Health Score example applies the schedule it prints
- Each of the three example bugs reintroduced in turn and confirmed caught
- `check-plugin-sync.py` green at 1.12.2

## Why the earlier sweeps missed all of this

None of these defects contained a date or an out-of-range value. `41` looks like a perfectly reasonable score. `Warning −5` looks like a perfectly reasonable deduction. They are only visible if you *run the maths* — which is what this suite now does on every commit, rather than reading for suspicious-looking numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)