### PR TITLE
fix: re-read the eight "corrected" files — three pointed at removed Google tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,54 @@
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+Re-read the eight files that PR #24 marked *"corrected"* — corrected for one specific thing each, and
+only scanned beyond it. Three carried further defects, all of the same kind: **instructions to use
+Google tools that no longer exist.** The oldest named a setting retired seven years ago. None carried
+a date or an odd-looking number, so every freshness sweep passed over them.
+
+- **`crawl-indexation.md` pointed at four removed or unsupported controls** — the section on
+  *"Crawl Rate Limit"* told readers to use `Crawl-delay` in robots.txt (**Googlebot has never
+  honoured it**; Bing and Yandex do) and described the Search Console crawl-rate setting as
+  *"legacy; Google mostly ignores this now"* when it was **removed on 8 January 2024**. Two rows of
+  the crawl-waste table sent readers to *"configure URL parameters in GSC (legacy tool, still
+  available)"* — **removed 28 April 2022** — and to *"set preferred domain in GSC"* — **retired in
+  2019**. Replaced with what actually works: server health and response time, `503`/`429` for
+  emergency throttling, and canonicals plus redirects for the duplicate cases.
+
+- **`international-seo.md` sent readers to a report removed four years ago** — *"GSC → Legacy Tools
+  → International Targeting"*. The report and its country-targeting setting were **removed on 22
+  September 2022**, and hreflang errors have not been reported in Search Console since. Rewritten
+  around the signals that still exist (hreflang, ccTLD, local signals) and pointing at
+  `scripts/hreflang_checker.py` for the validation Search Console no longer provides.
+
+- **`link-building.md` treated disavow as a routine remedy** — a *"Toxic link %"* scoring row made
+  `> 15%` mean *"disavow needed"*. Google's guidance is that **most sites never need the tool**: it
+  is for an active manual action or a documented negative-SEO campaign. Disavowing on a computed
+  score strips credit from borderline-but-legitimate links Google was still counting, for no
+  compensating gain. **"Toxic links" is a vendor metric Google does not use or publish.** Gated the
+  workflow, relabelled the metric, and fixed the tool path — the file pointed at *"Legacy Tools →
+  Disavow"* while `backlink-quality.md` pointed at *"Security & Manual Actions → Disavow"*; the tool
+  is neither, it is standalone.
+
+- **`backlink-quality.md`** (surfaced by the above, not itself in the reviewed set) — its workflow
+  auto-disavowed everything scored `high_risk` with no human confirmation, and carried the second
+  wrong tool path. Same gate applied; nothing is auto-disavowed.
+
+- **Verified clean, no further defects**: `image-seo.md` (sub-scores sum to 100; the AVIF/WebP
+  compression claims are mutually consistent against the JPEG baseline), `local-seo.md`,
+  `programmatic-seo.md` (its one Search Console path is current), `content-eeat.md` and
+  `core-eeat-framework.md`. Every sub-score allocation across all eight sums to 100, and every
+  `scripts/*.py` reference resolves.
+
+### Added
+
+- **`tests/test_removed_google_tools.py`** — 8 tests barring directives to use Google tooling that
+  has been removed, requiring disavow guidance to be gated on a manual action, and requiring any
+  "toxic" scoring to be labelled a vendor metric. The patterns match *instructions to use* a tool,
+  never mentions of it, so a file can freely explain that something was removed — that is how a
+  reader learns it is gone. Validated by reintroducing two of the defects.
 
 ## [1.12.3] - 2026-08-23
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/backlink-quality.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/backlink-quality.md
@@ -139,12 +139,20 @@ https://mixedsite.com/spammy-page
 
 ### Workflow
 
-1. Export toxic links from `link_profile.py` output.
-2. Filter: keep only high_risk (auto-disavow) + manually confirmed medium_risk.
-3. Group by domain — if ≥ 3 toxic URLs from same domain, escalate to `domain:`.
-4. Generate file with comments.
-5. Submit via Google Search Console > Security & Manual Actions > Disavow Links.
-6. Re-check in 4–8 weeks for impact.
+> **Gate first — do not run this workflow by default.** Google's guidance is that most sites never
+> need a disavow file. Proceed only with (1) an active **manual action** for unnatural links, or
+> (2) a documented negative-SEO campaign. Without one of those, Google already discounts these links
+> and disavowing on a computed score strips credit from borderline-but-legitimate domains for no
+> gain. The "toxic" scoring in this file is a **triage aid for deciding what to stop doing**, not a
+> disavow trigger — Google publishes no toxicity metric and does not use the term.
+
+1. Confirm the gate above applies. If it does not, stop here.
+2. Export the flagged links from `link_profile.py` output.
+3. Filter: high_risk **plus manual confirmation of every entry** — nothing is auto-disavowed.
+4. Group by domain — if ≥ 3 flagged URLs from the same domain, escalate to `domain:`.
+5. Generate file with comments.
+6. Submit at [search.google.com/search-console/disavow-links](https://search.google.com/search-console/disavow-links) — it is a standalone tool, not a page inside the Search Console navigation.
+7. Re-check in 4–8 weeks for impact.
 
 ---
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/content-eeat.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/content-eeat.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: corrected — September 2025 QRG re-verified as the current version -->
+<!-- 2026-08-23 review: re-read end to end 2026-08-23: no further defects — aggregation formula added in 1.12.3; September 2025 QRG still current -->
 
 # Content Quality & AI Citation Analysis
 ## Updated: August 2026

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/core-eeat-framework.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/core-eeat-framework.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: corrected — September 2025 QRG re-verified as the current version -->
+<!-- 2026-08-23 review: re-read end to end 2026-08-23: no further defects — scale normalisation fixed in 1.12.3; weight columns verified to sum to 100% -->
 <!-- Source: content-quality-auditor skill (aaron-he-zhu/core-eeat-content-benchmark) -->
 
 # CORE-EEAT Content Quality Framework

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/crawl-indexation.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/crawl-indexation.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: corrected — canonical re-evaluation ceiling added in 1.12.0; Googlebot-mobile and rel=next/prev claims re-checked -->
+<!-- 2026-08-23 review: re-read end to end 2026-08-23: four pointers to removed Google tooling — Crawl-delay (never supported by Googlebot), the crawl-rate limiter (removed 2024-01-08), the URL Parameters tool (removed 2022-04-28) and the preferred-domain setting (retired 2019) -->
 
 # Crawl Budget, Indexation & Canonicalization
 ## Updated: August 2026
@@ -25,9 +25,9 @@ Googlebot has a finite crawl budget per site — it determines how many pages ar
 
 ### 1. Crawl Rate Limit
 How fast Googlebot crawls without overloading your server. Controlled by:
-- Server health and response time (TTFB < 200ms = healthy)
-- `Crawl-delay` in robots.txt (use sparingly — can slow legitimate crawling)
-- GSC Crawl Stats report → "Crawl rate" setting (legacy; Google mostly ignores this now)
+- Server health and response time (TTFB < 200ms = healthy) — **this is the lever that actually works.** Googlebot backs off automatically on slow responses and 5xx/429 rates, and speeds up when the server is fast and healthy
+- **`Crawl-delay` is not supported by Googlebot** — Google has never honoured it. Bing and Yandex do. Never present it as a way to control Google's crawl rate
+- **The Search Console crawl-rate limiter was removed on January 8, 2024.** There is no setting to adjust. To slow Googlebot in an emergency, return `503`/`429` on the affected paths — and only briefly, since sustained 5xx leads to deindexing
 
 ### 2. Crawl Demand
 How often Google wants to crawl a URL based on:
@@ -52,10 +52,10 @@ How often Google wants to crawl a URL based on:
 |---|---|---|
 | Faceted navigation URLs | Crawl site, count `/color=red&size=M` style URLs | `noindex` or canonical → master category |
 | Paginated archive pages | Pages like `/blog/page/47` | Noindex paginated pages OR canonical all to page 1 (if content is largely duplicate) |
-| Session IDs / tracking parameters | URLs with `?utm_source=`, `?sessionid=` | Canonical to canonical URL; configure URL parameters in GSC (legacy tool, still available) |
+| Session IDs / tracking parameters | URLs with `?utm_source=`, `?sessionid=` | Canonical to canonical URL. **The GSC URL Parameters tool was removed on April 28, 2022** — do not send anyone there. Google handles parameters automatically; control them with canonicals, `robots.txt` patterns, and internal linking |
 | Thin tag / category pages | `/tag/red/`, `/category/all/` pages with < 300 words and no unique value | Noindex or consolidate |
 | Infinite scroll artifacts | Dynamic `?page=2`, `?offset=100` URLs | Proper pagination with `rel=next`/`prev` is deprecated — use view-all + canonical instead |
-| Duplicate HTTP/HTTPS or www/non-www | Four versions of homepage | 301 redirect all to single canonical; set preferred domain in GSC |
+| Duplicate HTTP/HTTPS or www/non-www | Four versions of homepage | 301 redirect all to a single canonical, and self-reference that canonical. **The GSC preferred-domain setting was retired in 2019** — redirects and canonicals are the only signals available |
 | Staging site crawlable | Staging URLs in search results | Block with robots.txt on staging; add noindex meta; do NOT rely on robots.txt alone |
 
 ### Medium-Priority Crawl Waste

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/image-seo.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/image-seo.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: corrected — JPEG XL browser-support row corrected against Chrome 145 status -->
+<!-- 2026-08-23 review: re-read end to end 2026-08-23: no further defects — sub-scores sum to 100, and the AVIF/WebP compression claims are mutually consistent against the JPEG baseline -->
 
 # Image SEO — Optimization Framework
 ## Updated: August 2026

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/international-seo.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/international-seo.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: corrected — added cross-language canonicalization rule (rule 6) + hreflang_checker diagnosis -->
+<!-- 2026-08-23 review: re-read end to end 2026-08-23: the International Targeting report and its country-targeting setting were removed 2022-09-22; hreflang errors are no longer reported in Search Console -->
 
 # International SEO & Hreflang
 ## Updated: August 2026
@@ -193,12 +193,22 @@ Keywords differ significantly across markets — never assume direct translation
 
 ## Geo-Targeting in Google Search Console
 
-For subdirectory or subdomain structures, set international targeting in GSC:
-1. GSC → Legacy Tools → International Targeting
-2. Select the correct country for each property
-3. For ccTLDs: Google automatically infers country — no manual setting needed
+> **There is no country-targeting setting any more.** The International Targeting report — which
+> carried both the country selector and the hreflang error report — was **deprecated in August 2022
+> and removed on 22 September 2022**. Do not send anyone to "GSC → Legacy Tools → International
+> Targeting"; it does not exist, and neither does the setting it contained.
 
-Note: This is a "soft" signal. Hreflang is the primary mechanism for multi-region targeting.
+**What replaced it: nothing, and nothing is needed.** Google withdrew country targeting because it
+was judged to add little value. The signals that actually determine geo-targeting are:
+
+1. **Hreflang** — the primary mechanism, and still fully supported. Google confirmed at removal that
+   its multilingual/multiregional recommendations were unchanged
+2. **ccTLD** — `example.de` is inferred automatically; nothing to configure
+3. **Server location / CDN, local links, local currency and address signals** — secondary
+
+**Hreflang errors are no longer reported in Search Console.** Validate them yourself with
+`scripts/hreflang_checker.py`, which covers all 8 rules including the cross-language canonical case
+Search Console never surfaced anyway.
 
 ---
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/link-building.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/link-building.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: corrected — AI-citation spam-policy entry added in 1.12.0 -->
+<!-- 2026-08-23 review: re-read end to end 2026-08-23: disavow presented as a routine remedy against Google's 'most sites never need it', driven by a vendor 'toxic link' metric Google does not recognise, plus a wrong tool path -->
 
 # Link Authority & Acquisition
 ## Updated: August 2026
@@ -82,7 +82,18 @@ Concentrate internal links toward:
 | Anchor text | Branded or descriptive | Exact match only | Gibberish |
 | Referring domain authority | High DA/DR (50+) | Low DA (< 20) | PBN patterns |
 
-### Red Flags — Links to Disavow
+### Red Flags — Low-Quality Link Patterns
+
+> **⚠ Do not reach for the disavow tool by default.** Google's guidance is that **most sites never
+> need it**. It is for two narrow cases: (1) an active **manual action** for unnatural links, or
+> (2) a documented negative-SEO campaign. Absent either, Google already ignores manipulative links,
+> and disavowing on a third-party score strips credit from borderline-but-legitimate links Google
+> was still counting — a weaker profile for no benefit.
+>
+> **"Toxic links" is a vendor metric, not a Google concept.** Google does not use the term and
+> publishes no toxicity score. Never present a tool's toxicity percentage as evidence that a disavow
+> is required. The patterns below are diagnostic — they tell you what kind of profile you have and
+> what to stop doing. They are **not** a disavow list.
 
 - Links from sites with no real traffic
 - Links from pages with >200 outbound links
@@ -100,7 +111,11 @@ domain:spamsite1.com
 domain:spamsite2.com
 https://specificpage.com/bad-link
 ```
-Submit via Google Search Console → Legacy Tools → Disavow Links.
+Submit at [search.google.com/search-console/disavow-links](https://search.google.com/search-console/disavow-links).
+
+**Before submitting, confirm one of the two qualifying cases applies** (manual action, or documented
+negative SEO). If neither does, the correct action is to stop acquiring bad links and let Google
+continue ignoring them — not to file a disavow.
 
 ---
 
@@ -247,7 +262,7 @@ Hi [Name],
 | Domain diversity | 50+ countries, 10+ TLDs | Mixed | Single source |
 | Anchor distribution | Balanced per table above | Slight imbalance | Exact-match heavy |
 | Link velocity | Consistent monthly growth | Occasional growth | Flat or declining |
-| Toxic link % | < 5% | 5-15% | > 15% (disavow needed) |
+| Low-quality referring domains % | < 5% | 5–15% | > 15% — investigate acquisition sources; **not** an automatic disavow trigger (see Red Flags above) |
 | Internal linking | Full pillar-cluster, no orphans | Mostly linked | Orphan pages present |
 
 ---

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/local-seo.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/local-seo.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: corrected — corrected 'Helpful Content' framing (merged into core, March 2024) -->
+<!-- 2026-08-23 review: re-read end to end 2026-08-23: no further defects — sub-scores sum to 100, no Google-tooling or Google-behaviour claims -->
 
 # Local SEO
 ## Updated: August 2026

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/programmatic-seo.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/programmatic-seo.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: corrected — corrected 'Helpful Content System' framing; AI-citation scaled-content row added in 1.12.0 -->
+<!-- 2026-08-23 review: re-read end to end 2026-08-23: no further defects — the one Search Console path it cites (Settings → Crawl Stats) is current -->
 
 # Programmatic SEO — Planning, Quality, & Execution
 ## Updated: August 2026

--- a/references/backlink-quality.md
+++ b/references/backlink-quality.md
@@ -139,12 +139,20 @@ https://mixedsite.com/spammy-page
 
 ### Workflow
 
-1. Export toxic links from `link_profile.py` output.
-2. Filter: keep only high_risk (auto-disavow) + manually confirmed medium_risk.
-3. Group by domain — if ≥ 3 toxic URLs from same domain, escalate to `domain:`.
-4. Generate file with comments.
-5. Submit via Google Search Console > Security & Manual Actions > Disavow Links.
-6. Re-check in 4–8 weeks for impact.
+> **Gate first — do not run this workflow by default.** Google's guidance is that most sites never
+> need a disavow file. Proceed only with (1) an active **manual action** for unnatural links, or
+> (2) a documented negative-SEO campaign. Without one of those, Google already discounts these links
+> and disavowing on a computed score strips credit from borderline-but-legitimate domains for no
+> gain. The "toxic" scoring in this file is a **triage aid for deciding what to stop doing**, not a
+> disavow trigger — Google publishes no toxicity metric and does not use the term.
+
+1. Confirm the gate above applies. If it does not, stop here.
+2. Export the flagged links from `link_profile.py` output.
+3. Filter: high_risk **plus manual confirmation of every entry** — nothing is auto-disavowed.
+4. Group by domain — if ≥ 3 flagged URLs from the same domain, escalate to `domain:`.
+5. Generate file with comments.
+6. Submit at [search.google.com/search-console/disavow-links](https://search.google.com/search-console/disavow-links) — it is a standalone tool, not a page inside the Search Console navigation.
+7. Re-check in 4–8 weeks for impact.
 
 ---
 

--- a/references/content-eeat.md
+++ b/references/content-eeat.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: corrected — September 2025 QRG re-verified as the current version -->
+<!-- 2026-08-23 review: re-read end to end 2026-08-23: no further defects — aggregation formula added in 1.12.3; September 2025 QRG still current -->
 
 # Content Quality & AI Citation Analysis
 ## Updated: August 2026

--- a/references/core-eeat-framework.md
+++ b/references/core-eeat-framework.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: corrected — September 2025 QRG re-verified as the current version -->
+<!-- 2026-08-23 review: re-read end to end 2026-08-23: no further defects — scale normalisation fixed in 1.12.3; weight columns verified to sum to 100% -->
 <!-- Source: content-quality-auditor skill (aaron-he-zhu/core-eeat-content-benchmark) -->
 
 # CORE-EEAT Content Quality Framework

--- a/references/crawl-indexation.md
+++ b/references/crawl-indexation.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: corrected — canonical re-evaluation ceiling added in 1.12.0; Googlebot-mobile and rel=next/prev claims re-checked -->
+<!-- 2026-08-23 review: re-read end to end 2026-08-23: four pointers to removed Google tooling — Crawl-delay (never supported by Googlebot), the crawl-rate limiter (removed 2024-01-08), the URL Parameters tool (removed 2022-04-28) and the preferred-domain setting (retired 2019) -->
 
 # Crawl Budget, Indexation & Canonicalization
 ## Updated: August 2026
@@ -25,9 +25,9 @@ Googlebot has a finite crawl budget per site — it determines how many pages ar
 
 ### 1. Crawl Rate Limit
 How fast Googlebot crawls without overloading your server. Controlled by:
-- Server health and response time (TTFB < 200ms = healthy)
-- `Crawl-delay` in robots.txt (use sparingly — can slow legitimate crawling)
-- GSC Crawl Stats report → "Crawl rate" setting (legacy; Google mostly ignores this now)
+- Server health and response time (TTFB < 200ms = healthy) — **this is the lever that actually works.** Googlebot backs off automatically on slow responses and 5xx/429 rates, and speeds up when the server is fast and healthy
+- **`Crawl-delay` is not supported by Googlebot** — Google has never honoured it. Bing and Yandex do. Never present it as a way to control Google's crawl rate
+- **The Search Console crawl-rate limiter was removed on January 8, 2024.** There is no setting to adjust. To slow Googlebot in an emergency, return `503`/`429` on the affected paths — and only briefly, since sustained 5xx leads to deindexing
 
 ### 2. Crawl Demand
 How often Google wants to crawl a URL based on:
@@ -52,10 +52,10 @@ How often Google wants to crawl a URL based on:
 |---|---|---|
 | Faceted navigation URLs | Crawl site, count `/color=red&size=M` style URLs | `noindex` or canonical → master category |
 | Paginated archive pages | Pages like `/blog/page/47` | Noindex paginated pages OR canonical all to page 1 (if content is largely duplicate) |
-| Session IDs / tracking parameters | URLs with `?utm_source=`, `?sessionid=` | Canonical to canonical URL; configure URL parameters in GSC (legacy tool, still available) |
+| Session IDs / tracking parameters | URLs with `?utm_source=`, `?sessionid=` | Canonical to canonical URL. **The GSC URL Parameters tool was removed on April 28, 2022** — do not send anyone there. Google handles parameters automatically; control them with canonicals, `robots.txt` patterns, and internal linking |
 | Thin tag / category pages | `/tag/red/`, `/category/all/` pages with < 300 words and no unique value | Noindex or consolidate |
 | Infinite scroll artifacts | Dynamic `?page=2`, `?offset=100` URLs | Proper pagination with `rel=next`/`prev` is deprecated — use view-all + canonical instead |
-| Duplicate HTTP/HTTPS or www/non-www | Four versions of homepage | 301 redirect all to single canonical; set preferred domain in GSC |
+| Duplicate HTTP/HTTPS or www/non-www | Four versions of homepage | 301 redirect all to a single canonical, and self-reference that canonical. **The GSC preferred-domain setting was retired in 2019** — redirects and canonicals are the only signals available |
 | Staging site crawlable | Staging URLs in search results | Block with robots.txt on staging; add noindex meta; do NOT rely on robots.txt alone |
 
 ### Medium-Priority Crawl Waste

--- a/references/image-seo.md
+++ b/references/image-seo.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: corrected — JPEG XL browser-support row corrected against Chrome 145 status -->
+<!-- 2026-08-23 review: re-read end to end 2026-08-23: no further defects — sub-scores sum to 100, and the AVIF/WebP compression claims are mutually consistent against the JPEG baseline -->
 
 # Image SEO — Optimization Framework
 ## Updated: August 2026

--- a/references/international-seo.md
+++ b/references/international-seo.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: corrected — added cross-language canonicalization rule (rule 6) + hreflang_checker diagnosis -->
+<!-- 2026-08-23 review: re-read end to end 2026-08-23: the International Targeting report and its country-targeting setting were removed 2022-09-22; hreflang errors are no longer reported in Search Console -->
 
 # International SEO & Hreflang
 ## Updated: August 2026
@@ -193,12 +193,22 @@ Keywords differ significantly across markets — never assume direct translation
 
 ## Geo-Targeting in Google Search Console
 
-For subdirectory or subdomain structures, set international targeting in GSC:
-1. GSC → Legacy Tools → International Targeting
-2. Select the correct country for each property
-3. For ccTLDs: Google automatically infers country — no manual setting needed
+> **There is no country-targeting setting any more.** The International Targeting report — which
+> carried both the country selector and the hreflang error report — was **deprecated in August 2022
+> and removed on 22 September 2022**. Do not send anyone to "GSC → Legacy Tools → International
+> Targeting"; it does not exist, and neither does the setting it contained.
 
-Note: This is a "soft" signal. Hreflang is the primary mechanism for multi-region targeting.
+**What replaced it: nothing, and nothing is needed.** Google withdrew country targeting because it
+was judged to add little value. The signals that actually determine geo-targeting are:
+
+1. **Hreflang** — the primary mechanism, and still fully supported. Google confirmed at removal that
+   its multilingual/multiregional recommendations were unchanged
+2. **ccTLD** — `example.de` is inferred automatically; nothing to configure
+3. **Server location / CDN, local links, local currency and address signals** — secondary
+
+**Hreflang errors are no longer reported in Search Console.** Validate them yourself with
+`scripts/hreflang_checker.py`, which covers all 8 rules including the cross-language canonical case
+Search Console never surfaced anyway.
 
 ---
 

--- a/references/link-building.md
+++ b/references/link-building.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: corrected — AI-citation spam-policy entry added in 1.12.0 -->
+<!-- 2026-08-23 review: re-read end to end 2026-08-23: disavow presented as a routine remedy against Google's 'most sites never need it', driven by a vendor 'toxic link' metric Google does not recognise, plus a wrong tool path -->
 
 # Link Authority & Acquisition
 ## Updated: August 2026
@@ -82,7 +82,18 @@ Concentrate internal links toward:
 | Anchor text | Branded or descriptive | Exact match only | Gibberish |
 | Referring domain authority | High DA/DR (50+) | Low DA (< 20) | PBN patterns |
 
-### Red Flags — Links to Disavow
+### Red Flags — Low-Quality Link Patterns
+
+> **⚠ Do not reach for the disavow tool by default.** Google's guidance is that **most sites never
+> need it**. It is for two narrow cases: (1) an active **manual action** for unnatural links, or
+> (2) a documented negative-SEO campaign. Absent either, Google already ignores manipulative links,
+> and disavowing on a third-party score strips credit from borderline-but-legitimate links Google
+> was still counting — a weaker profile for no benefit.
+>
+> **"Toxic links" is a vendor metric, not a Google concept.** Google does not use the term and
+> publishes no toxicity score. Never present a tool's toxicity percentage as evidence that a disavow
+> is required. The patterns below are diagnostic — they tell you what kind of profile you have and
+> what to stop doing. They are **not** a disavow list.
 
 - Links from sites with no real traffic
 - Links from pages with >200 outbound links
@@ -100,7 +111,11 @@ domain:spamsite1.com
 domain:spamsite2.com
 https://specificpage.com/bad-link
 ```
-Submit via Google Search Console → Legacy Tools → Disavow Links.
+Submit at [search.google.com/search-console/disavow-links](https://search.google.com/search-console/disavow-links).
+
+**Before submitting, confirm one of the two qualifying cases applies** (manual action, or documented
+negative SEO). If neither does, the correct action is to stop acquiring bad links and let Google
+continue ignoring them — not to file a disavow.
 
 ---
 
@@ -247,7 +262,7 @@ Hi [Name],
 | Domain diversity | 50+ countries, 10+ TLDs | Mixed | Single source |
 | Anchor distribution | Balanced per table above | Slight imbalance | Exact-match heavy |
 | Link velocity | Consistent monthly growth | Occasional growth | Flat or declining |
-| Toxic link % | < 5% | 5-15% | > 15% (disavow needed) |
+| Low-quality referring domains % | < 5% | 5–15% | > 15% — investigate acquisition sources; **not** an automatic disavow trigger (see Red Flags above) |
 | Internal linking | Full pillar-cluster, no orphans | Mostly linked | Orphan pages present |
 
 ---

--- a/references/local-seo.md
+++ b/references/local-seo.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: corrected — corrected 'Helpful Content' framing (merged into core, March 2024) -->
+<!-- 2026-08-23 review: re-read end to end 2026-08-23: no further defects — sub-scores sum to 100, no Google-tooling or Google-behaviour claims -->
 
 # Local SEO
 ## Updated: August 2026

--- a/references/programmatic-seo.md
+++ b/references/programmatic-seo.md
@@ -1,5 +1,5 @@
 <!-- Updated: 2026-08-23 | Review: 2027-02-23 -->
-<!-- 2026-08-23 review: corrected — corrected 'Helpful Content System' framing; AI-citation scaled-content row added in 1.12.0 -->
+<!-- 2026-08-23 review: re-read end to end 2026-08-23: no further defects — the one Search Console path it cites (Settings → Crawl Stats) is current -->
 
 # Programmatic SEO — Planning, Quality, & Execution
 ## Updated: August 2026

--- a/tests/test_removed_google_tools.py
+++ b/tests/test_removed_google_tools.py
@@ -1,0 +1,115 @@
+"""Never send a user to a Google tool that no longer exists.
+
+Advice pointing at a removed tool is worse than no advice: the reader follows it,
+finds nothing, and has no way to tell whether they are looking in the wrong place
+or the guidance is stale. Four such pointers shipped in the reference set, the
+oldest naming a tool retired seven years earlier:
+
+  * Search Console **preferred domain** setting -- retired 2019
+  * Search Console **URL Parameters** tool -- removed 28 April 2022
+  * Search Console **International Targeting** report -- removed 22 September 2022
+  * Search Console **crawl rate limiter** -- removed 8 January 2024
+
+Plus ``Crawl-delay`` presented as a way to control Googlebot, which has never
+honoured it.
+
+None of these carried a date or a suspicious number, so every freshness sweep
+passed over them. They are only visible if you know the tool is gone.
+
+The patterns below match *instructions to use* the tool, not mentions of it. A
+file is free -- encouraged -- to say "this was removed in 2022"; that is how a
+reader learns the tool is gone. What is barred is a navigation path or an
+imperative pointing at it.
+"""
+
+import glob
+import os
+import re
+
+import pytest
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+
+# (label, pattern) -- each matches a directive to go and use the tool.
+REMOVED_TOOL_DIRECTIVES = [
+    (
+        "Search Console preferred domain setting (retired 2019)",
+        r"set (?:the )?preferred domain in (?:GSC|Search Console)",
+    ),
+    (
+        "Search Console URL Parameters tool (removed 2022-04-28)",
+        r"configure URL parameters in (?:GSC|Search Console)",
+    ),
+    (
+        "Search Console International Targeting report (removed 2022-09-22)",
+        r"(?<!\")GSC\s*(?:→|->)\s*Legacy Tools\s*(?:→|->)\s*International Targeting",
+    ),
+    (
+        "Search Console crawl rate limiter (removed 2024-01-08)",
+        r'"Crawl rate" setting \(legacy',
+    ),
+    (
+        "Crawl-delay as a Googlebot control (never supported)",
+        r"`Crawl-delay` in robots\.txt \(use sparingly",
+    ),
+    (
+        "disavow tool under a Search Console menu path (it is standalone)",
+        r"Search Console\s*(?:>|→|->)\s*(?:Legacy Tools|Security & Manual Actions)\s*(?:>|→|->)\s*Disavow",
+    ),
+]
+
+MARKDOWN = sorted(
+    glob.glob(os.path.join(ROOT, "references", "**", "*.md"), recursive=True)
+) + [os.path.join(ROOT, "AGENTS.md"), os.path.join(ROOT, "SKILL.md")]
+
+
+@pytest.mark.parametrize("label,pattern", REMOVED_TOOL_DIRECTIVES, ids=lambda x: x if isinstance(x, str) and " " not in x[:6] else None)
+def test_no_directive_to_removed_google_tool(label, pattern):
+    """No file may instruct a reader to use a tool Google has removed."""
+    offenders = []
+    for path in MARKDOWN:
+        if not os.path.isfile(path):
+            continue
+        with open(path, encoding="utf-8") as fh:
+            for n, line in enumerate(fh, 1):
+                # A line explaining that the tool is gone is the fix, not the bug.
+                if re.search(r"removed|retired|deprecat|no longer|does not exist|not supported", line, re.I):
+                    continue
+                if re.search(pattern, line, re.I):
+                    offenders.append(f"{os.path.relpath(path, ROOT)}:{n}")
+    assert not offenders, f"Directive to use a removed tool — {label}\n  " + "\n  ".join(offenders)
+
+
+def test_disavow_guidance_is_gated():
+    """Disavow must be gated on manual action or negative SEO, not a toxicity score.
+
+    Google's position is that most sites never need the tool, and that disavowing
+    on a vendor "toxic" score strips credit from borderline-but-legitimate links
+    that were still counting. Both files that describe the workflow must say so.
+    """
+    for rel in ("link-building.md", "backlink-quality.md"):
+        path = os.path.join(ROOT, "references", rel)
+        with open(path, encoding="utf-8") as fh:
+            text = fh.read()
+        if "disavow" not in text.lower():
+            continue
+        assert re.search(r"manual action", text, re.I), (
+            f"{rel} describes disavowing without gating it on a manual action."
+        )
+        assert re.search(r"most sites (?:never|will not|do not)", text, re.I), (
+            f"{rel} describes disavowing without stating that most sites never need it."
+        )
+
+
+def test_toxic_links_labelled_as_vendor_metric():
+    """Wherever a "toxic" score drives advice, say Google does not use the term."""
+    for rel in ("link-building.md", "backlink-quality.md"):
+        path = os.path.join(ROOT, "references", rel)
+        with open(path, encoding="utf-8") as fh:
+            text = fh.read()
+        if not re.search(r"toxic", text, re.I):
+            continue
+        assert re.search(r"(vendor metric|not a Google concept|does not use the term)", text, re.I), (
+            f"{rel} uses 'toxic' scoring without noting it is a vendor metric Google does not "
+            f"recognise. Presenting it as a Google signal is how it ends up driving disavows."
+        )


### PR DESCRIPTION
#24 corrected these eight for **one specific thing each** and only scanned beyond it. Reading them end to end found three carrying further defects — all of the same kind: **instructions to use Google tooling that no longer exists.**

The oldest named a setting retired **seven years ago**. None carried a date or an odd-looking number, which is why every freshness sweep passed over them.

## `crawl-indexation.md` — four removed or unsupported controls

Its "Crawl Rate Limit" section told readers to use `Crawl-delay` in robots.txt — **Googlebot has never honoured it** (Bing and Yandex do) — and described the Search Console crawl-rate setting as *"legacy; Google mostly ignores this now"* when it was **removed 8 January 2024**.

Two rows of the crawl-waste table sent readers to:
- *"configure URL parameters in GSC (legacy tool, still available)"* — **removed 28 April 2022**
- *"set preferred domain in GSC"* — **retired 2019**

Replaced with what actually works: server health and response time, `503`/`429` for emergency throttling, canonicals and redirects for the duplicate cases.

## `international-seo.md` — a report removed four years ago

*"GSC → Legacy Tools → International Targeting."* That report and its country-targeting setting were **removed 22 September 2022**, and hreflang errors have not been reported in Search Console since. Rewritten around the signals that still exist — hreflang, ccTLD, local signals — and pointing at `scripts/hreflang_checker.py` for the validation Search Console no longer provides.

## `link-building.md` — disavow as a routine remedy

A *"Toxic link %"* scoring row made `> 15%` mean **"disavow needed."**

Google's guidance is that **most sites never need the tool**: it's for an active manual action or a documented negative-SEO campaign. Disavowing on a computed score strips credit from borderline-but-legitimate links Google was still counting — a weaker profile for no compensating gain. And **"toxic links" is a vendor metric Google neither uses nor publishes.**

Gated the workflow, relabelled the metric, fixed the tool path — this file said *"Legacy Tools → Disavow"* while `backlink-quality.md` said *"Security & Manual Actions → Disavow."* It is neither; the tool is standalone.

## `backlink-quality.md` — surfaced by the above

Not in the reviewed set, but its workflow **auto-disavowed** everything scored `high_risk` with no human confirmation, and carried the second wrong path. Same gate applied; nothing is auto-disavowed now.

## Verified clean

`image-seo.md` (sub-scores sum to 100; AVIF/WebP compression claims are mutually consistent against the JPEG baseline), `local-seo.md`, `programmatic-seo.md` (its one Search Console path is current), `content-eeat.md`, `core-eeat-framework.md`.

Every sub-score allocation across all eight sums to 100, and every `scripts/*.py` reference resolves.

## Verification

- `pytest tests/` — **216 passed** (was 208)
- `tests/test_removed_google_tools.py` — 8 tests. Patterns match instructions to *use* a removed tool, never mentions of it, so a file can still explain that something was removed — that's how a reader learns it's gone
- Validated by reintroducing two of the defects
- `check-plugin-sync.py` green at 1.12.3

## Still open

The FAQ Search Console API question is **unchanged** — no `GSC_CREDENTIALS` configured, and it cannot be answered unauthenticated. Everything else about it is documented, including the practice-problem conflation trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)