### PR TITLE
chore: release 1.12.4 — fold [Unreleased] and bump version

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
     "name": "Myk Pono"
   },
   "metadata": {
-    "version": "1.12.3"
+    "version": "1.12.4"
   },
   "plugins": [
     {
       "name": "ultimate-seo-geo",
       "description": "Scored SEO audits for developers/marketers using AI agents: technical health, JSON-LD, E-E-A-T, backlinks, GEO (AI Overviews, ChatGPT, Perplexity). 46 scripts; HTML/Excel/PDF. E-commerce schema, drift monitoring, topic clustering, Google API tiers, maps intelligence. Optional MCP (Firecrawl, DataForSEO). Parallel workers: agents/PARALLEL-AUDIT.md. Modes: Audit → Plan → Execute.",
-      "version": "1.12.3",
+      "version": "1.12.4",
       "author": {
         "name": "Myk Pono",
         "url": "https://lab.mykpono.com"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.3 |
+| **Version** | 1.12.4 |
 | **Updated** | 2026-08-22 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,27 +2,15 @@
 
 ## [Unreleased]
 
-### Added
+_Nothing yet._
 
-- **`scripts/check_tag_matches_version.py` + `.github/workflows/verify-release-tag.yml`** — verifies
-  that a release tag points at a tree which actually declares that version. **v1.12.2 and v1.12.3
-  were both tagged against a local `main` that had not pulled the release-prep merge**, so each tag
-  sat one merge too early and the tagged tree self-reported the *previous* version. Both times the
-  release notes were correct — they are generated from the CHANGELOG on disk, not from the tag — so
-  nothing looked wrong until someone installed from the tag.
-  - `check_version_sync.py` cannot catch this: it checks the **working tree**, which is consistent
-    right after a bump. The defect is in what the tag points at.
-  - Runs in its own workflow, because the main one filters `push` by path and **path filters never
-    match a tag push** — a tag job added there would have silently never run.
-  - On failure it names the commit that does carry the version bump and prints the exact
-    `git tag -f` to fix it, rather than just reporting a mismatch.
-  - Excluded from the plugin bundle (`setup-plugin.sh`, `check-plugin-sync.py`) alongside the other
-    maintainer-only tooling; it needs git history and is useless to plugin users.
+## [1.12.4] - 2026-08-23
 
-- **`tests/test_tag_version_check.py`** — 12 tests covering the extractors, tag-pattern matching, and
-  two guards on the checker itself: that every path it reads exists, and that it covers every file
-  declaring a version. An incomplete source list is the worst failure mode for a guard — it passes by
-  finding nothing to compare, and looks green.
+Closes out the audit sequence. The eight files PR #24 marked *"corrected"* were corrected for one
+thing each and only scanned beyond it — reading them found three more pointing at Google tooling
+that no longer exists, the oldest naming a setting retired seven years ago. Separately, two
+consecutive releases were tagged one merge too early, so the tagged tree self-reported the previous
+version; that now fails CI instead of going unnoticed until someone installs from the tag.
 
 ### Fixed
 
@@ -32,13 +20,6 @@
     section for its own version, so both shipped a bundle reporting the wrong version to users
   - Left in place deliberately: all three are long superseded, and moving published tags is
     disruptive for no benefit. Recorded here so the history is not silently clean.
-
-### Fixed
-
-Re-read the eight files that PR #24 marked *"corrected"* — corrected for one specific thing each, and
-only scanned beyond it. Three carried further defects, all of the same kind: **instructions to use
-Google tools that no longer exist.** The oldest named a setting retired seven years ago. None carried
-a date or an odd-looking number, so every freshness sweep passed over them.
 
 - **`crawl-indexation.md` pointed at four removed or unsupported controls** — the section on
   *"Crawl Rate Limit"* told readers to use `Crawl-delay` in robots.txt (**Googlebot has never
@@ -75,6 +56,26 @@ a date or an odd-looking number, so every freshness sweep passed over them.
   `scripts/*.py` reference resolves.
 
 ### Added
+
+- **`scripts/check_tag_matches_version.py` + `.github/workflows/verify-release-tag.yml`** — verifies
+  that a release tag points at a tree which actually declares that version. **v1.12.2 and v1.12.3
+  were both tagged against a local `main` that had not pulled the release-prep merge**, so each tag
+  sat one merge too early and the tagged tree self-reported the *previous* version. Both times the
+  release notes were correct — they are generated from the CHANGELOG on disk, not from the tag — so
+  nothing looked wrong until someone installed from the tag.
+  - `check_version_sync.py` cannot catch this: it checks the **working tree**, which is consistent
+    right after a bump. The defect is in what the tag points at.
+  - Runs in its own workflow, because the main one filters `push` by path and **path filters never
+    match a tag push** — a tag job added there would have silently never run.
+  - On failure it names the commit that does carry the version bump and prints the exact
+    `git tag -f` to fix it, rather than just reporting a mismatch.
+  - Excluded from the plugin bundle (`setup-plugin.sh`, `check-plugin-sync.py`) alongside the other
+    maintainer-only tooling; it needs git history and is useless to plugin users.
+
+- **`tests/test_tag_version_check.py`** — 12 tests covering the extractors, tag-pattern matching, and
+  two guards on the checker itself: that every path it reads exists, and that it covers every file
+  declaring a version. An incomplete source list is the worst failure mode for a guard — it passes by
+  finding nothing to compare, and looks green.
 
 - **`tests/test_removed_google_tools.py`** — 8 tests barring directives to use Google tooling that
   has been removed, requiring disavow guidance to be gated on a manual action, and requiring any

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![AGENTS.md](https://img.shields.io/badge/AGENTS.md-compatible-blue)](https://agents.md)
-[![Version](https://img.shields.io/badge/version-1.12.3-green.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.12.4-green.svg)](CHANGELOG.md)
 [![LLM-Agnostic](https://img.shields.io/badge/LLM--Agnostic-7%2B%20platforms-purple.svg)](#platform-compatibility)
 
 The definitive SEO and Generative Engine Optimization agent for AI coding tools. LLM-agnostic — works on any platform that reads `AGENTS.md`. Runs full site audits with scored findings, generates ready-to-deploy fixes, and optimizes content for both Google Search and AI search engines (Google AI Overviews, AI Mode, ChatGPT Search, Perplexity). Exports HTML, Excel, and PDF reports.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ultimate-seo-geo
 description: Audits and optimizes websites for search engine visibility (SEO) and AI search citation (GEO), covering technical health, E-E-A-T content scoring, domain authority, structured data, rich results, and entity signals. Use when running SEO audits, diagnosing traffic drops or ranking losses, generating Schema.org JSON-LD, checking Core Web Vitals, crawlability, robots.txt, sitemaps, hreflang, backlinks, planning content strategy or site migrations, fixing indexing issues, or optimizing for AI Overviews, ChatGPT, and Perplexity. NOT for paid ads (PPC/SEM), social media strategy, email marketing, or general web development unrelated to search.
-version: 1.12.3
+version: 1.12.4
 ---
 
 # Ultimate SEO + GEO — LLM-Agnostic SEO Agent
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.3 |
+| **Version** | 1.12.4 |
 | **Updated** | 2026-08-12 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/plugins/ultimate-seo-geo/.claude-plugin/plugin.json
+++ b/plugins/ultimate-seo-geo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ultimate-seo-geo",
   "description": "Scored SEO audits for developers and marketers using AI agents: technical health, Schema.org JSON-LD, E-E-A-T, backlinks, domain signals, GEO (AI Overviews, ChatGPT, Perplexity). 46 bundled scripts; HTML/Excel/PDF reports. E-commerce schema, drift monitoring, topic clustering, Google API tiers (GSC/GA4), maps intelligence. Optional MCP (Firecrawl, DataForSEO): references/optional-extensions-mcp.md. Modes: Audit → Plan → Execute.",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "author": {
     "name": "Myk Pono",
     "url": "https://lab.mykpono.com"

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
@@ -2,7 +2,7 @@
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.3 |
+| **Version** | 1.12.4 |
 | **Updated** | 2026-08-22 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/SKILL.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ultimate-seo-geo
 description: Audits and optimizes websites for search engine visibility (SEO) and AI search citation (GEO), covering technical health, E-E-A-T content scoring, domain authority, structured data, rich results, and entity signals. Use when running SEO audits, diagnosing traffic drops or ranking losses, generating Schema.org JSON-LD, checking Core Web Vitals, crawlability, robots.txt, sitemaps, hreflang, backlinks, planning content strategy or site migrations, fixing indexing issues, or optimizing for AI Overviews, ChatGPT, and Perplexity. NOT for paid ads (PPC/SEM), social media strategy, email marketing, or general web development unrelated to search.
-version: 1.12.3
+version: 1.12.4
 ---
 
 # Ultimate SEO + GEO — LLM-Agnostic SEO Agent
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.3 |
+| **Version** | 1.12.4 |
 | **Updated** | 2026-08-12 |
 | **License** | MIT |
 | **Author** | Myk Pono |


### PR DESCRIPTION
`main` sat **4 commits ahead** of `v1.12.3`, carrying the eight-file re-review and the release-tag verification tooling — neither described by the published release.

## What's in it

- `[Unreleased]` folded into **`[1.12.4]` — 2026-08-23**, with a lead tying the two pieces together: the files #24 marked *"corrected"* were corrected for one thing each and only scanned beyond it, and two consecutive releases were tagged one merge too early.
- Version bumped **1.12.3 → 1.12.4** across all six locations.
- `[Unreleased]` empty again.

## Rebuilt the subsections again

This time the headers weren't *stranded* — #33's entry was well-formed — but the block ended up with **duplicate `### Fixed` and `### Added` headings**, one pair from each PR. Every bullet was reclassified from scratch: **9 bullets, 6 Fixed and 3 Added**, collapsed into one canonical subsection each.

That's the **fourth** `[Unreleased]` structural drift in this sequence — #25, #28 and #30 stranded entries under the wrong heading; #33 duplicated headings instead. Rebuilding on every fold is now the routine rather than the exception, which is why this one caught it before merge instead of two PRs later.

## Verification

- All **9** bullets preserved (9 before, 9 after, none lost) — checked programmatically against `HEAD:CHANGELOG.md`
- Exactly one `### Fixed` and one `### Added`; classification verified
- `pytest tests/` — **228 passed**
- `check-plugin-sync.py` and `check_version_sync.py` — green at **1.12.4**
- Release notes extraction: **79 clean lines, 0 blockquote lines** to strip

## After merge — yours to run

```bash
git checkout main && git pull && git tag v1.12.4 && git push origin v1.12.4
```

```bash
gh release create v1.12.4 --title "v1.12.4 — removed-tool audit and release-tag verification" --notes "$(sed -n '/^## \[1.12.4\]/,/^## \[1.12.3\]/p' CHANGELOG.md | sed '$d')"
```

**This is the first tag the new guard will see.** Pushing it triggers `verify-release-tag.yml`, which checks that the tagged tree actually declares `1.12.4` and that the CHANGELOG has a matching section. If the tag lands early again — as v1.12.2 and v1.12.3 both did — it fails within a minute and prints the exact `git tag -f` to fix it, rather than sitting quietly until someone installs from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)