### PR TITLE
fix: make the FAQ-settling command actually runnable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,35 @@
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **The command this repo recommended for settling the FAQ API question could not run** —
+  `references/schema-types.md` told readers to run `scripts/gsc_query.py` grouped by
+  `searchAppearance`. The script's `--dimension` choices were `query, page, country, device, date`.
+  **`searchAppearance` was not among them**, so the recommended command died on an argparse error
+  before touching the network. `searchAppearance` and `hour` are both valid Search Analytics API
+  dimensions and are now accepted.
+  - Nothing caught this because the advice was never run: it needs credentials, and *"needs
+    credentials"* reads identically to *"blocked"* whether or not the command is even valid. A
+    documented command that cannot parse is worse than none — it sends the reader hunting for a
+    credentials problem that does not exist.
+  - The FAQ note now carries the exact runnable command, a **90-day** window (a shorter one can
+    return nothing simply because the property had no FAQ-eligible impressions, which looks
+    identical to the data having been withdrawn), and how to read the result: an absent FAQ row
+    only means something if the property demonstrably had FAQ impressions before May 2026.
+
+- **`references/audit-script-matrix.md` documented a flag that does not exist** — the
+  `gsc_query.py` row, added in 1.12.0, invoked `--property SITE`. The script takes the site URL
+  **positionally**. Found by the new guard below, not by review. (`gsc_export.py` genuinely does
+  take `--property`, which is likely how the confusion arose.)
+
+### Added
+
+- **`tests/test_documented_commands.py`** — 7 static checks comparing what the docs invoke against
+  what the scripts declare: every `python scripts/X.py` names a real script, every `--flag` is
+  declared by that script, every `--flag value` is within that flag's `choices`, and `gsc_query.py`
+  accepts the API dimensions. No execution, no network, no credentials. Validated by reintroducing
+  both defects above.
 
 ## [1.12.4] - 2026-08-23
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/audit-script-matrix.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/audit-script-matrix.md
@@ -41,7 +41,7 @@ Each major automated check has a **script** you can run alone (usually with `--j
 | Maps / GBP intelligence | §25 | `maps_checker.py` | `python scripts/maps_checker.py URL --json` |
 | Core Web Vitals history (CrUX) | §4 | `crux_history.py` | `python scripts/crux_history.py URL --metric lcp --json` |
 | SEO drift baseline / compare | §22 | `drift_monitor.py` | `python scripts/drift_monitor.py baseline URL` then `compare URL` |
-| GSC performance query (Tier 1) | §10 | `gsc_query.py` | `python scripts/gsc_query.py --property SITE --dimension page --json` |
+| GSC performance query (Tier 1) | §10 | `gsc_query.py` | `python scripts/gsc_query.py sc-domain:example.com --dimension page --json` (site URL is positional, not a flag) |
 | GSC URL inspection export (Tier 1) | §10 | `gsc_export.py` | `python scripts/gsc_export.py --property SITE --sitemap-url URL` |
 | GSC generative-AI impressions (manual CSV) | §10 | `gsc_ai_import.py` | `python scripts/gsc_ai_import.py export.csv --json` |
 | GA4 organic reporting (Tier 1) | §10 | `ga4_report.py` | `python scripts/ga4_report.py --property 123456789 --organic-only --json` |

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/schema-types.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/references/schema-types.md
@@ -87,10 +87,21 @@ These types no longer generate Google rich results but are still valid Schema.or
 > states the FAQ phases with such confidence. Check which feature an entry names before treating it as
 > evidence.
 >
-> **What would actually settle it**: an authenticated `searchanalytics.query` grouped by
-> `searchAppearance` against a property with FAQ history, checking whether an FAQ value is still
-> returned. `scripts/gsc_query.py` can run it once credentials are configured (`GSC_CREDENTIALS`);
-> unauthenticated checks cannot answer this.
+> **What would actually settle it** — a single authenticated query against a property with FAQ
+> history, checking whether an FAQ value still comes back:
+>
+> ```bash
+> python scripts/gsc_query.py sc-domain:example.com --dimension searchAppearance --days 90 --json
+> ```
+>
+> Requires `GSC_CREDENTIALS` (or `GOOGLE_APPLICATION_CREDENTIALS`); unauthenticated checks cannot
+> answer this. Use a **90-day** window — a shorter one can return nothing simply because the
+> property had no FAQ-eligible impressions in the period, which looks identical to the data having
+> been withdrawn.
+>
+> **Reading the result**: an FAQ row present means the API still returns it. An FAQ row *absent*
+> while other appearance types are present is consistent with the sunset — but confirm the property
+> actually had FAQ impressions before May 2026, or absence proves nothing about the API.
 >
 > **Actionable regardless of confirmation**: any dashboard, BigQuery export or scheduled job still
 > querying FAQ rich-result data should be checked against live responses, because the documented

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/gsc_query.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/gsc_query.py
@@ -221,9 +221,16 @@ def main():
     )
     parser.add_argument(
         "--dimension",
-        choices=["query", "page", "country", "device", "date"],
+        # Full set the Search Analytics API accepts. searchAppearance and hour
+        # were missing, which made the documented "group by searchAppearance"
+        # workflow in references/schema-types.md impossible to actually run.
+        choices=["query", "page", "country", "device", "date", "searchAppearance", "hour"],
         default="query",
-        help="Primary dimension to group by (default: query)",
+        help=(
+            "Primary dimension to group by (default: query). "
+            "'searchAppearance' lists the rich-result types a property appears as — "
+            "the only way to check whether a given appearance type still returns data."
+        ),
     )
     parser.add_argument(
         "--top-pages", type=int,

--- a/references/audit-script-matrix.md
+++ b/references/audit-script-matrix.md
@@ -41,7 +41,7 @@ Each major automated check has a **script** you can run alone (usually with `--j
 | Maps / GBP intelligence | §25 | `maps_checker.py` | `python scripts/maps_checker.py URL --json` |
 | Core Web Vitals history (CrUX) | §4 | `crux_history.py` | `python scripts/crux_history.py URL --metric lcp --json` |
 | SEO drift baseline / compare | §22 | `drift_monitor.py` | `python scripts/drift_monitor.py baseline URL` then `compare URL` |
-| GSC performance query (Tier 1) | §10 | `gsc_query.py` | `python scripts/gsc_query.py --property SITE --dimension page --json` |
+| GSC performance query (Tier 1) | §10 | `gsc_query.py` | `python scripts/gsc_query.py sc-domain:example.com --dimension page --json` (site URL is positional, not a flag) |
 | GSC URL inspection export (Tier 1) | §10 | `gsc_export.py` | `python scripts/gsc_export.py --property SITE --sitemap-url URL` |
 | GSC generative-AI impressions (manual CSV) | §10 | `gsc_ai_import.py` | `python scripts/gsc_ai_import.py export.csv --json` |
 | GA4 organic reporting (Tier 1) | §10 | `ga4_report.py` | `python scripts/ga4_report.py --property 123456789 --organic-only --json` |

--- a/references/schema-types.md
+++ b/references/schema-types.md
@@ -87,10 +87,21 @@ These types no longer generate Google rich results but are still valid Schema.or
 > states the FAQ phases with such confidence. Check which feature an entry names before treating it as
 > evidence.
 >
-> **What would actually settle it**: an authenticated `searchanalytics.query` grouped by
-> `searchAppearance` against a property with FAQ history, checking whether an FAQ value is still
-> returned. `scripts/gsc_query.py` can run it once credentials are configured (`GSC_CREDENTIALS`);
-> unauthenticated checks cannot answer this.
+> **What would actually settle it** — a single authenticated query against a property with FAQ
+> history, checking whether an FAQ value still comes back:
+>
+> ```bash
+> python scripts/gsc_query.py sc-domain:example.com --dimension searchAppearance --days 90 --json
+> ```
+>
+> Requires `GSC_CREDENTIALS` (or `GOOGLE_APPLICATION_CREDENTIALS`); unauthenticated checks cannot
+> answer this. Use a **90-day** window — a shorter one can return nothing simply because the
+> property had no FAQ-eligible impressions in the period, which looks identical to the data having
+> been withdrawn.
+>
+> **Reading the result**: an FAQ row present means the API still returns it. An FAQ row *absent*
+> while other appearance types are present is consistent with the sunset — but confirm the property
+> actually had FAQ impressions before May 2026, or absence proves nothing about the API.
 >
 > **Actionable regardless of confirmation**: any dashboard, BigQuery export or scheduled job still
 > querying FAQ rich-result data should be checked against live responses, because the documented

--- a/scripts/gsc_query.py
+++ b/scripts/gsc_query.py
@@ -221,9 +221,16 @@ def main():
     )
     parser.add_argument(
         "--dimension",
-        choices=["query", "page", "country", "device", "date"],
+        # Full set the Search Analytics API accepts. searchAppearance and hour
+        # were missing, which made the documented "group by searchAppearance"
+        # workflow in references/schema-types.md impossible to actually run.
+        choices=["query", "page", "country", "device", "date", "searchAppearance", "hour"],
         default="query",
-        help="Primary dimension to group by (default: query)",
+        help=(
+            "Primary dimension to group by (default: query). "
+            "'searchAppearance' lists the rich-result types a property appears as — "
+            "the only way to check whether a given appearance type still returns data."
+        ),
     )
     parser.add_argument(
         "--top-pages", type=int,

--- a/tests/test_documented_commands.py
+++ b/tests/test_documented_commands.py
@@ -1,0 +1,122 @@
+"""Commands printed in the references must actually run.
+
+`references/schema-types.md` told readers -- four separate times across this
+session's PRs -- to settle the FAQ API question by running `gsc_query.py`
+"grouped by searchAppearance". The script's `--dimension` choices were
+`query, page, country, device, date`. `searchAppearance` was not among them, so
+the recommended command died on an argparse error before touching the network.
+
+Nothing caught it because the advice was never run: it needs credentials, and
+"needs credentials" reads the same as "blocked" whether or not the command is
+even valid. A documented command that cannot parse is worse than no command --
+it sends the reader looking for a credentials problem that isn't there.
+
+These checks are static: they compare what the docs invoke against what the
+scripts declare, without executing anything or requiring network access.
+"""
+
+import glob
+import os
+import re
+
+import pytest
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+SCRIPTS = os.path.join(ROOT, "scripts")
+
+DOC_FILES = sorted(glob.glob(os.path.join(ROOT, "references", "**", "*.md"), recursive=True)) + [
+    os.path.join(ROOT, "AGENTS.md"),
+    os.path.join(ROOT, "SKILL.md"),
+]
+
+# `python scripts/foo.py ...` up to end of line or a closing backtick.
+INVOCATION = re.compile(r"python3?\s+scripts/([\w-]+\.py)((?:\s+[^\n`]*)?)")
+
+
+def _iter_invocations():
+    for path in DOC_FILES:
+        if not os.path.isfile(path):
+            continue
+        with open(path, encoding="utf-8") as fh:
+            for n, line in enumerate(fh, 1):
+                for m in INVOCATION.finditer(line):
+                    yield os.path.relpath(path, ROOT), n, m.group(1), m.group(2)
+
+
+def _script_source(name):
+    p = os.path.join(SCRIPTS, name)
+    if not os.path.isfile(p):
+        return None
+    with open(p, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_documented_scripts_exist():
+    """Every `python scripts/X.py` in the docs must name a real script."""
+    missing = {
+        f"{doc}:{line} -> {script}"
+        for doc, line, script, _ in _iter_invocations()
+        if _script_source(script) is None
+    }
+    assert not missing, "documented commands reference scripts that do not exist:\n  " + "\n  ".join(sorted(missing))
+
+
+def test_documented_flags_are_accepted_by_the_script():
+    """Every `--flag` in a documented command must be declared by that script."""
+    bad = []
+    for doc, line, script, args in _iter_invocations():
+        src = _script_source(script)
+        if src is None:
+            continue
+        declared = set(re.findall(r'"(--[\w-]+)"', src)) | set(re.findall(r"'(--[\w-]+)'", src))
+        for flag in re.findall(r"(?<![\w-])(--[\w-]+)", args):
+            if flag not in declared:
+                bad.append(f"{doc}:{line} -> {script} does not accept {flag}")
+    assert not bad, "documented commands use flags the script does not declare:\n  " + "\n  ".join(bad)
+
+
+def test_documented_choice_values_are_valid():
+    """A documented `--flag value` must be in that flag's `choices`, when it has any.
+
+    This is the check that would have caught `--dimension searchAppearance`.
+    """
+    bad = []
+    for doc, line, script, args in _iter_invocations():
+        src = _script_source(script)
+        if src is None:
+            continue
+        for flag, value in re.findall(r"(?<![\w-])(--[\w-]+)[= ]([\w-]+)", args):
+            # Find a choices=[...] within the add_argument block that declares this flag.
+            m = re.search(
+                rf'["\']{re.escape(flag)}["\'][^)]*?choices=\[([^\]]*)\]',
+                src,
+                re.S,
+            )
+            if not m:
+                continue
+            choices = set(re.findall(r"[\"']([\w-]+)[\"']", m.group(1)))
+            if value.isupper() or value.startswith("["):
+                continue  # placeholder like URL / N, not a literal value
+            if value not in choices:
+                bad.append(
+                    f"{doc}:{line} -> {script} {flag}={value} not in {sorted(choices)}"
+                )
+    assert not bad, "documented commands pass values outside the flag's choices:\n  " + "\n  ".join(bad)
+
+
+@pytest.mark.parametrize("dimension", ["searchAppearance", "query", "page", "date"])
+def test_gsc_query_accepts_the_api_dimensions(dimension):
+    """gsc_query.py must accept the dimensions the Search Analytics API defines.
+
+    searchAppearance is the one that matters: it is the only way to ask whether a
+    given rich-result type still returns data, which is exactly the open FAQ
+    question in references/schema-types.md.
+    """
+    src = _script_source("gsc_query.py")
+    m = re.search(r'"--dimension",.*?choices=\[([^\]]*)\]', src, re.S)
+    assert m, "gsc_query.py no longer declares --dimension choices"
+    choices = set(re.findall(r'"([\w-]+)"', m.group(1)))
+    assert dimension in choices, (
+        f"gsc_query.py --dimension does not accept '{dimension}'. "
+        f"Declared: {sorted(choices)}"
+    )


### PR DESCRIPTION
I've told you four times across this session that one authenticated query settles the FAQ Search Console API question — *"run `scripts/gsc_query.py` grouped by `searchAppearance`."*

**That command could not run.** The script's `--dimension` choices were `query, page, country, device, date`. `searchAppearance` was not among them, so it would have died on an argparse error before touching the network. The advice is also written into `references/schema-types.md`, so the repo shipped it.

## Why it survived four rounds

The advice was never executed. It needs credentials, and **"needs credentials" reads identically to "blocked"** whether or not the command is even valid. Every time I reported the item as open, I was reporting a credentials blocker that was masking a second, entirely fixable one.

A documented command that can't parse is worse than no command — it sends the reader hunting for a credentials problem that doesn't exist.

## Fixed

`searchAppearance` and `hour` are both valid Search Analytics API dimensions (verified against Google's API reference; the only documented restriction on `searchAppearance` concerns `byNewsShowcasePanel` aggregation, which doesn't apply). Both are now accepted.

The FAQ note in `schema-types.md` now carries:

```bash
python scripts/gsc_query.py sc-domain:example.com --dimension searchAppearance --days 90 --json
```

— plus **why 90 days** (a shorter window can return nothing simply because the property had no FAQ-eligible impressions, which looks identical to the data having been withdrawn) and **how to read the result** (an absent FAQ row means nothing unless the property demonstrably had FAQ impressions before May 2026).

## The guard found a second one immediately

`references/audit-script-matrix.md`'s `gsc_query.py` row — **added in 1.12.0, by me** — invoked `--property SITE`. The script takes the site URL **positionally**. `gsc_export.py` genuinely does take `--property`, which is likely how the confusion arose.

## `tests/test_documented_commands.py`

7 static checks comparing what the docs invoke against what the scripts declare:

- every `python scripts/X.py` in the docs names a real script
- every `--flag` is declared by that script
- every `--flag value` falls within that flag's `choices`
- `gsc_query.py` accepts the API dimensions, `searchAppearance` especially

No execution, no network, no credentials — so it runs in CI and catches exactly the class of defect that "I can't run this" was hiding.

## Verification

- `pytest tests/` — **235 passed** (was 228)
- Both defects reintroduced in turn and confirmed caught
- `check-plugin-sync.py` green at 1.12.4

## Status of the FAQ question itself

**Still unanswered** — no credentials available. But the blocker is now genuinely and only credentials. Point `GSC_CREDENTIALS` at a property with FAQ history and the command above works as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)