### PR TITLE
fix: tag checker suggested the wrong commit to fix a bad tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@
   **positionally**. Found by the new guard below, not by review. (`gsc_export.py` genuinely does
   take `--property`, which is likely how the confusion arose.)
 
+- **`check_tag_matches_version.py` suggested the wrong commit to fix a bad tag** — on its first live
+  run (v1.12.4, which was mis-tagged like the two before it) the checker correctly failed, then
+  named `7661274` as the fix target. That was the merge *after* the release-prep one, carrying work
+  1.12.4 was never meant to include. `_likely_correct_commit` returned the **newest** commit
+  declaring the version, which over-shoots the moment `main` moves past the release.
+  - Walking plain history instead **under-shoots**: it returns the bump commit inside the release
+    branch (`432e14d`) rather than the merge that put it on `main` (`db531ae`). Fixed with
+    `--first-parent`, which keeps the walk on the main line. Verified against all three mis-tagged
+    releases — the helper now returns exactly the commit each tag was hand-corrected to.
+  - A checker that reports a real failure and then hands over a wrong command is close to the worst
+    outcome available: it is authoritative enough to be trusted and specific enough to be run.
+
 ### Added
 
 - **`tests/test_documented_commands.py`** — 7 static checks comparing what the docs invoke against

--- a/scripts/check_tag_matches_version.py
+++ b/scripts/check_tag_matches_version.py
@@ -79,21 +79,39 @@ def _extract(text: str, how: str) -> str | None:
 
 
 def _likely_correct_commit(expected: str) -> str | None:
-    """Find the newest commit whose tree declares `expected`.
+    """Find the commit where `expected` was introduced — the release-prep merge.
 
-    When a tag lands early, the commit that actually carries the version bump is
-    a little further along the same branch. Reporting it turns a bare failure
-    into a runnable fix.
+    Walking newest-first and returning the first match finds the *newest* commit
+    declaring the version, which over-shoots as soon as `main` moves past the
+    release. That is what happened on v1.12.4: the checker suggested the merge
+    after the release-prep one, which carried work the release was never meant
+    to include.
+
+    Instead, walk the **first-parent** history back through the contiguous run of
+    commits declaring `expected`, and return the oldest of them — the merge that
+    put the bump on main. First-parent matters: a plain walk descends into the
+    release branch and returns the bump commit itself, which is not what you tag.
     """
-    code, out = _git("log", "--format=%H", "-40", "HEAD")
+    # --first-parent keeps us on the main line. Without it the walk descends into
+    # the release branch and returns the bump commit itself (e.g. 432e14d) rather
+    # than the merge that put it on main (db531ae) — which is what you tag.
+    code, out = _git("log", "--first-parent", "--format=%H", "-80", "HEAD")
     if code != 0:
         return None
+
+    candidate = None
     for sha in out.splitlines():
         text = _show(sha, "SKILL.md")
-        if text and _extract(text, "frontmatter") == expected:
-            code2, short = _git("rev-parse", "--short", sha)
-            return short if code2 == 0 else sha[:7]
-    return None
+        declares = bool(text) and _extract(text, "frontmatter") == expected
+        if declares:
+            candidate = sha          # keep walking back through the run
+        elif candidate is not None:
+            break                    # walked past the bump; candidate is its first commit
+
+    if candidate is None:
+        return None
+    code2, short = _git("rev-parse", "--short", candidate)
+    return short if code2 == 0 else candidate[:7]
 
 
 def main() -> int:
@@ -157,7 +175,7 @@ def main() -> int:
         "release-prep merge was pulled. It is what happened to v1.12.2 and v1.12.3."
     )
     if hint:
-        print(f"\nThe version bump appears at {hint}. If that is the intended release commit:")
+        print(f"\nThe {expected} version bump landed at {hint} — that is almost certainly the\nrelease-prep merge and the correct target:")
         print(f"    git tag -f {tag} {hint} && git push origin -f {tag}")
     else:
         print("\nFind the commit that carries the version bump, then move the tag onto it.")

--- a/tests/test_tag_version_check.py
+++ b/tests/test_tag_version_check.py
@@ -16,6 +16,7 @@ tags, so they run anywhere without mutating the repository.
 import importlib.util
 import json
 import os
+import re
 
 import pytest
 
@@ -88,3 +89,76 @@ def test_sources_cover_every_file_that_declares_a_version():
         "plugins/ultimate-seo-geo/skills/ultimate-seo-geo/SKILL.md",
     }
     assert expected <= tracked, f"version-declaring files not checked at tag time: {expected - tracked}"
+
+def test_likely_correct_commit_returns_the_bump_merge_not_a_later_one():
+    """The suggested fix must be where the bump landed, not the newest match.
+
+    v1.12.4 exposed both failure modes in turn. Returning the *newest* commit
+    declaring the version over-shoots as soon as main moves past the release --
+    it suggested the merge after the release-prep one, carrying work the release
+    was never meant to include. Walking plain history instead under-shoots into
+    the release branch and returns the bump commit, which is not on main and is
+    not what you tag.
+
+    Asserted as a property rather than a fixed SHA, so it cannot rot: the commit
+    returned must declare the version, and its first parent must not -- that is
+    precisely "the merge that introduced it on the main line".
+    """
+    import subprocess
+
+    def _sh(*args):
+        return subprocess.run(["git", *args], capture_output=True, text=True)
+
+    # Pick a version that exists in this repo's history.
+    head = _sh("show", "HEAD:SKILL.md").stdout
+    version = tagcheck._extract(head, "frontmatter")
+    assert version, "could not read the current version from SKILL.md"
+
+    sha = tagcheck._likely_correct_commit(version)
+    assert sha, f"helper found no commit introducing {version}"
+
+    at_commit = tagcheck._show(sha, "SKILL.md")
+    assert at_commit and tagcheck._extract(at_commit, "frontmatter") == version, (
+        f"{sha} does not declare {version}"
+    )
+
+    parent = _sh("rev-parse", f"{sha}^1")
+    if parent.returncode == 0:
+        at_parent = tagcheck._show(parent.stdout.strip(), "SKILL.md")
+        parent_version = tagcheck._extract(at_parent, "frontmatter") if at_parent else None
+        assert parent_version != version, (
+            f"{sha} is not where {version} was introduced — its first parent already "
+            f"declares {parent_version}, so the helper is over-shooting."
+        )
+
+    # "declares X, parent does not" is true of the branch commit as well as the merge
+    # that landed it, so it cannot tell them apart on its own. The commit must also sit
+    # on the first-parent path — that is what makes it taggable.
+    main_line = _sh("rev-list", "--first-parent", "HEAD")
+    if main_line.returncode == 0:
+        full = _sh("rev-parse", sha).stdout.strip()
+        assert full in main_line.stdout.split(), (
+            f"{sha} declares {version} but is not on the first-parent path of HEAD — it is a "
+            f"commit inside a release branch, not the merge that put the bump on main. "
+            f"Tagging it would point at history that was never on the main line."
+        )
+
+
+def test_likely_correct_commit_walks_first_parent_only():
+    """Guard the flag in the actual git call, not merely somewhere in the source.
+
+    The first version of this test searched the whole function body for the string
+    "--first-parent". That string also appears in the docstring and a comment, so
+    deleting the flag from the `_git(...)` call left the test green — a guard that
+    passes by matching its own explanation.
+    """
+    import inspect
+
+    src = inspect.getsource(tagcheck._likely_correct_commit)
+    call = re.search(r'_git\(\s*"log"\s*,(.*?)\)', src, re.S)
+    assert call, "_likely_correct_commit no longer calls _git('log', ...)"
+    assert '"--first-parent"' in call.group(1), (
+        "_likely_correct_commit's git log call no longer passes --first-parent. Without "
+        "it the walk descends into the release branch and suggests a commit that is not "
+        f"on main.\n  call args: {call.group(1).strip()}"
+    )


### PR DESCRIPTION
On its **first live run** — v1.12.4, mis-tagged like the two before it — the checker did its job: fired on the tag push, failed in 11 seconds. Then it named `7661274` as the fix target.

That was the merge **after** the release-prep one, carrying work 1.12.4 was never meant to include. `_likely_correct_commit` returned the *newest* commit declaring the version, which over-shoots the moment `main` moves past the release.

**A checker that reports a real failure and then hands over a wrong command is close to the worst outcome available** — authoritative enough to be trusted, specific enough to be run.

## The fix isn't just "walk further back"

Walking plain history **under-shoots**: it returns the bump commit inside the release branch (`432e14d`) rather than the merge that landed it on `main` (`db531ae`). One is on the main line and taggable; the other isn't.

`--first-parent` keeps the walk on the main line. Verified against all three mis-tagged releases — the helper now returns exactly the commit each tag was hand-corrected to:

| Version | Helper returns | Tag actually points at |
|---|---|---|
| 1.12.4 | `db531ae` | `db531ae` ✓ |
| 1.12.3 | `50c33e3` | `50c33e3` ✓ |
| 1.12.2 | `c3ab0b6` | `c3ab0b6` ✓ |

Those targets were established independently, by hand, before this fix existed — so agreement is real validation rather than a tautology.

## Both regression tests initially missed the under-shoot

Worth stating plainly, because it's the same failure the suite is supposed to prevent:

**The flag guard searched the whole function body for `"--first-parent"`.** That string also appears in the docstring and a comment — so deleting the flag from the actual `_git(...)` call left the test green. A guard that passes by matching its own explanation. It now inspects the arguments of the `_git("log", ...)` call.

**The property test asserted "declares X, first parent does not"** — which is true of the branch commit as well as the merge that landed it, so it couldn't tell them apart. It now also requires the commit to sit on the first-parent path of `HEAD`.

Re-validated: **over-shoot fails 1 test, under-shoot fails 2.** Before this, the under-shoot failed none.

## Verification

- `pytest tests/` — **237 passed** (was 235)
- Both failure modes reintroduced in turn and confirmed caught
- `check-plugin-sync.py` green at 1.12.4
- `v1.12.4` now points at `db531ae` and passes the checker cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)