### PR TITLE
chore: release 1.12.5 — fold [Unreleased] and bump version

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
     "name": "Myk Pono"
   },
   "metadata": {
-    "version": "1.12.4"
+    "version": "1.12.5"
   },
   "plugins": [
     {
       "name": "ultimate-seo-geo",
       "description": "Scored SEO audits for developers/marketers using AI agents: technical health, JSON-LD, E-E-A-T, backlinks, GEO (AI Overviews, ChatGPT, Perplexity). 46 scripts; HTML/Excel/PDF. E-commerce schema, drift monitoring, topic clustering, Google API tiers, maps intelligence. Optional MCP (Firecrawl, DataForSEO). Parallel workers: agents/PARALLEL-AUDIT.md. Modes: Audit → Plan → Execute.",
-      "version": "1.12.4",
+      "version": "1.12.5",
       "author": {
         "name": "Myk Pono",
         "url": "https://lab.mykpono.com"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.4 |
+| **Version** | 1.12.5 |
 | **Updated** | 2026-08-22 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [1.12.5] - 2026-08-23
+
+Three defects, each found by the fix before it. The command this repo recommended four times for
+settling the FAQ Search Console API question could not parse; the guard written to catch that found a
+second invented flag immediately; and the release-tag checker, on its first live run, correctly
+failed a bad tag and then named the wrong commit to fix it.
+
 ### Fixed
 
 - **The command this repo recommended for settling the FAQ API question could not run** —

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![AGENTS.md](https://img.shields.io/badge/AGENTS.md-compatible-blue)](https://agents.md)
-[![Version](https://img.shields.io/badge/version-1.12.4-green.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.12.5-green.svg)](CHANGELOG.md)
 [![LLM-Agnostic](https://img.shields.io/badge/LLM--Agnostic-7%2B%20platforms-purple.svg)](#platform-compatibility)
 
 The definitive SEO and Generative Engine Optimization agent for AI coding tools. LLM-agnostic — works on any platform that reads `AGENTS.md`. Runs full site audits with scored findings, generates ready-to-deploy fixes, and optimizes content for both Google Search and AI search engines (Google AI Overviews, AI Mode, ChatGPT Search, Perplexity). Exports HTML, Excel, and PDF reports.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ultimate-seo-geo
 description: Audits and optimizes websites for search engine visibility (SEO) and AI search citation (GEO), covering technical health, E-E-A-T content scoring, domain authority, structured data, rich results, and entity signals. Use when running SEO audits, diagnosing traffic drops or ranking losses, generating Schema.org JSON-LD, checking Core Web Vitals, crawlability, robots.txt, sitemaps, hreflang, backlinks, planning content strategy or site migrations, fixing indexing issues, or optimizing for AI Overviews, ChatGPT, and Perplexity. NOT for paid ads (PPC/SEM), social media strategy, email marketing, or general web development unrelated to search.
-version: 1.12.4
+version: 1.12.5
 ---
 
 # Ultimate SEO + GEO — LLM-Agnostic SEO Agent
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.4 |
+| **Version** | 1.12.5 |
 | **Updated** | 2026-08-12 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/plugins/ultimate-seo-geo/.claude-plugin/plugin.json
+++ b/plugins/ultimate-seo-geo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ultimate-seo-geo",
   "description": "Scored SEO audits for developers and marketers using AI agents: technical health, Schema.org JSON-LD, E-E-A-T, backlinks, domain signals, GEO (AI Overviews, ChatGPT, Perplexity). 46 bundled scripts; HTML/Excel/PDF reports. E-commerce schema, drift monitoring, topic clustering, Google API tiers (GSC/GA4), maps intelligence. Optional MCP (Firecrawl, DataForSEO): references/optional-extensions-mcp.md. Modes: Audit → Plan → Execute.",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "author": {
     "name": "Myk Pono",
     "url": "https://lab.mykpono.com"

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
@@ -2,7 +2,7 @@
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.4 |
+| **Version** | 1.12.5 |
 | **Updated** | 2026-08-22 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/SKILL.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ultimate-seo-geo
 description: Audits and optimizes websites for search engine visibility (SEO) and AI search citation (GEO), covering technical health, E-E-A-T content scoring, domain authority, structured data, rich results, and entity signals. Use when running SEO audits, diagnosing traffic drops or ranking losses, generating Schema.org JSON-LD, checking Core Web Vitals, crawlability, robots.txt, sitemaps, hreflang, backlinks, planning content strategy or site migrations, fixing indexing issues, or optimizing for AI Overviews, ChatGPT, and Perplexity. NOT for paid ads (PPC/SEM), social media strategy, email marketing, or general web development unrelated to search.
-version: 1.12.4
+version: 1.12.5
 ---
 
 # Ultimate SEO + GEO — LLM-Agnostic SEO Agent
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.4 |
+| **Version** | 1.12.5 |
 | **Updated** | 2026-08-12 |
 | **License** | MIT |
 | **Author** | Myk Pono |


### PR DESCRIPTION
`main` sat **4 commits ahead** of `v1.12.4`, carrying three defects — each found by the fix before it.

## What's in it

- `[Unreleased]` folded into **`[1.12.5]` — 2026-08-23**
- Version bumped **1.12.4 → 1.12.5** across all six locations
- `[Unreleased]` empty again

## The chain

1. **The command this repo recommended four times couldn't parse.** `references/schema-types.md` said to settle the FAQ Search Console API question by running `gsc_query.py` grouped by `searchAppearance` — which wasn't among the script's `--dimension` choices. It would have died on an argparse error before touching the network. It survived because the advice was never executed: *"needs credentials"* reads identically to *"blocked"* whether or not the command is valid.
2. **The guard written to catch that found a second one immediately** — `audit-script-matrix.md` invoked `gsc_query.py --property SITE`. The script takes the site URL positionally. That row was added in 1.12.0.
3. **The release-tag checker's first live run** — against the mis-tagged v1.12.4 — correctly failed in 11 seconds, then named the wrong commit to fix it. It returned the newest commit declaring the version, which over-shoots once `main` moves past the release. Walking plain history under-shoots into the release branch instead; `--first-parent` was the actual fix.

## `[Unreleased]` needed no repair this time

One `Fixed`, one `Added`, nothing stranded or duplicated — because the over-shoot entry was inserted *into* the existing subsection rather than prepended as a new one. Rebuilt anyway per the routine established after four consecutive drifts (#25, #28, #30, #33), and verified: **4 bullets in, 4 out, one heading each.**

## Verification

- `pytest tests/` — **237 passed**
- `check-plugin-sync.py` and `check_version_sync.py` — green at **1.12.5**
- Release notes extraction: **49 clean lines, 0 blockquote lines**

## After merge — yours to run

```bash
git checkout main && git pull && git tag v1.12.5 && git push origin v1.12.5
```

```bash
gh release create v1.12.5 --title "v1.12.5 — runnable commands and tag-checker accuracy" --notes "$(sed -n '/^## \[1.12.5\]/,/^## \[1.12.4\]/p' CHANGELOG.md | sed '$d')"
```

The tag guard runs on push. **All three previous releases were tagged one merge early**, so if it happens again you'll get a red check within a minute — and this time the suggested fix command will be the right one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)