### PR TITLE
chore: release 1.12.6 — fold [Unreleased] and bump version

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
     "name": "Myk Pono"
   },
   "metadata": {
-    "version": "1.12.5"
+    "version": "1.12.6"
   },
   "plugins": [
     {
       "name": "ultimate-seo-geo",
       "description": "Scored SEO audits for developers/marketers using AI agents: technical health, JSON-LD, E-E-A-T, backlinks, GEO (AI Overviews, ChatGPT, Perplexity). 46 scripts; HTML/Excel/PDF. E-commerce schema, drift monitoring, topic clustering, Google API tiers, maps intelligence. Optional MCP (Firecrawl, DataForSEO). Parallel workers: agents/PARALLEL-AUDIT.md. Modes: Audit → Plan → Execute.",
-      "version": "1.12.5",
+      "version": "1.12.6",
       "author": {
         "name": "Myk Pono",
         "url": "https://lab.mykpono.com"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.5 |
+| **Version** | 1.12.6 |
 | **Updated** | 2026-08-22 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [1.12.6] - 2026-08-23
+
+Three defects, all in the setup path for the one question this repo still cannot answer — whether
+the Search Console API stopped returning FAQ data in August 2026. That path is where nothing looks,
+because *"blocked on credentials"* reads as a complete explanation on its own. It was hiding an
+uncommitted requirements file, an incomplete dependency list, and a verification procedure whose
+prerequisite could only be satisfied by the thing it was a prerequisite for.
+
 ### Fixed
 
 - **The FAQ verification procedure was circular** (`references/schema-types.md`) — it said to run the
@@ -32,14 +42,6 @@
   All four imports across both scripts are now covered, with a comment on each line saying which
   script needs it.
 
-### Added
-
-- **`tests/test_requirements_files.py`** — 4 tests: every `pip install -r X.txt` printed anywhere in
-  the repo names a file that exists **and is tracked by git**, and `requirements-gsc.txt` covers
-  every Google import in both GSC scripts. The tracked-by-git check is the one that matters here —
-  existing on disk is not enough, and is precisely why this survived. Validated by dropping the
-  package and by untracking the file.
-
 ### Changed
 
 - **`.gitignore` now covers Google service-account keys** — `gsc-oauth-token.json` and
@@ -51,6 +53,14 @@
   `*-credentials.json`, `client_secret*.json`, `*.pem` and `*.p12`.
   - Every pattern was checked against all 10 tracked `.json` files first; none collide, and all
     tracked files remain visible to git after the change.
+
+### Added
+
+- **`tests/test_requirements_files.py`** — 4 tests: every `pip install -r X.txt` printed anywhere in
+  the repo names a file that exists **and is tracked by git**, and `requirements-gsc.txt` covers
+  every Google import in both GSC scripts. The tracked-by-git check is the one that matters here —
+  existing on disk is not enough, and is precisely why this survived. Validated by dropping the
+  package and by untracking the file.
 
 ## [1.12.5] - 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![AGENTS.md](https://img.shields.io/badge/AGENTS.md-compatible-blue)](https://agents.md)
-[![Version](https://img.shields.io/badge/version-1.12.5-green.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.12.6-green.svg)](CHANGELOG.md)
 [![LLM-Agnostic](https://img.shields.io/badge/LLM--Agnostic-7%2B%20platforms-purple.svg)](#platform-compatibility)
 
 The definitive SEO and Generative Engine Optimization agent for AI coding tools. LLM-agnostic — works on any platform that reads `AGENTS.md`. Runs full site audits with scored findings, generates ready-to-deploy fixes, and optimizes content for both Google Search and AI search engines (Google AI Overviews, AI Mode, ChatGPT Search, Perplexity). Exports HTML, Excel, and PDF reports.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ultimate-seo-geo
 description: Audits and optimizes websites for search engine visibility (SEO) and AI search citation (GEO), covering technical health, E-E-A-T content scoring, domain authority, structured data, rich results, and entity signals. Use when running SEO audits, diagnosing traffic drops or ranking losses, generating Schema.org JSON-LD, checking Core Web Vitals, crawlability, robots.txt, sitemaps, hreflang, backlinks, planning content strategy or site migrations, fixing indexing issues, or optimizing for AI Overviews, ChatGPT, and Perplexity. NOT for paid ads (PPC/SEM), social media strategy, email marketing, or general web development unrelated to search.
-version: 1.12.5
+version: 1.12.6
 ---
 
 # Ultimate SEO + GEO — LLM-Agnostic SEO Agent
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.5 |
+| **Version** | 1.12.6 |
 | **Updated** | 2026-08-12 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/plugins/ultimate-seo-geo/.claude-plugin/plugin.json
+++ b/plugins/ultimate-seo-geo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ultimate-seo-geo",
   "description": "Scored SEO audits for developers and marketers using AI agents: technical health, Schema.org JSON-LD, E-E-A-T, backlinks, domain signals, GEO (AI Overviews, ChatGPT, Perplexity). 46 bundled scripts; HTML/Excel/PDF reports. E-commerce schema, drift monitoring, topic clustering, Google API tiers (GSC/GA4), maps intelligence. Optional MCP (Firecrawl, DataForSEO): references/optional-extensions-mcp.md. Modes: Audit → Plan → Execute.",
-  "version": "1.12.5",
+  "version": "1.12.6",
   "author": {
     "name": "Myk Pono",
     "url": "https://lab.mykpono.com"

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
@@ -2,7 +2,7 @@
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.5 |
+| **Version** | 1.12.6 |
 | **Updated** | 2026-08-22 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/SKILL.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ultimate-seo-geo
 description: Audits and optimizes websites for search engine visibility (SEO) and AI search citation (GEO), covering technical health, E-E-A-T content scoring, domain authority, structured data, rich results, and entity signals. Use when running SEO audits, diagnosing traffic drops or ranking losses, generating Schema.org JSON-LD, checking Core Web Vitals, crawlability, robots.txt, sitemaps, hreflang, backlinks, planning content strategy or site migrations, fixing indexing issues, or optimizing for AI Overviews, ChatGPT, and Perplexity. NOT for paid ads (PPC/SEM), social media strategy, email marketing, or general web development unrelated to search.
-version: 1.12.5
+version: 1.12.6
 ---
 
 # Ultimate SEO + GEO — LLM-Agnostic SEO Agent
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.5 |
+| **Version** | 1.12.6 |
 | **Updated** | 2026-08-12 |
 | **License** | MIT |
 | **Author** | Myk Pono |


### PR DESCRIPTION
`main` sat **6 commits ahead** of `v1.12.5`, carrying three defects that share an origin worth naming.

## All three were in the same blind spot

Every one sits in the setup path for the single question this repo still can't answer — whether the Search Console API stopped returning FAQ data in August 2026.

**That path is where nothing looks, because "blocked on credentials" reads as a complete explanation on its own.** It was hiding:

1. `requirements-gsc.txt` referenced by four scripts and **never committed** — present only on one machine, absent in every clone
2. That file **missing `google-api-python-client`**, so the documented install satisfied `gsc_export.py` and left `gsc_query.py` failing on `ImportError`
3. A verification procedure whose prerequisite — *"confirm the property had FAQ impressions before May 2026"* — **could only be satisfied by the authenticated query it was a prerequisite for**

Plus the `.gitignore` hardening for service-account keys, which are long-lived credentials with no expiry.

## `[Unreleased]` needed no repair

One `Fixed`, one `Changed`, one `Added` — nothing stranded or duplicated, for the second release running. Rebuilt anyway per the routine established after four consecutive drifts, and verified: **5 bullets in, 5 out, no duplicate headings.**

## Verification

- `pytest tests/` — **241 passed**
- `check-plugin-sync.py` and `check_version_sync.py` — green at **1.12.6**
- Release notes extraction: **58 clean lines, 0 blockquote lines**

## After merge — yours to run

```bash
git checkout main && git pull && git tag v1.12.6 && git push origin v1.12.6
```

```bash
gh release create v1.12.6 --title "v1.12.6 — GSC setup path fixes" --notes "$(sed -n '/^## \[1.12.6\]/,/^## \[1.12.5\]/p' CHANGELOG.md | sed '$d')"
```

v1.12.5 was the first tag in four to land correctly first time. The guard runs on push either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)