### PR TITLE
chore: gitignore tier-3-4-implementation-brief.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,12 @@ __pycache__/
 .venv/
 venv/
 
+# Planning brief written against v1.10.0; contains a personal machine path.
+# Every feature it proposed (F1-F8, S1-S2) has since shipped, so it is a record
+# of completed work rather than a plan. Named explicitly, not globbed — a
+# *brief*.md pattern would also swallow output from scripts/content_brief.py.
+tier-3-4-implementation-brief.md
+
 # Cursor rules that contain personal machine paths
 .cursor/rules/filesystem-access.mdc
 ultimate-seo-geo-workspace/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Changed
 
+- **`.gitignore` covers `tier-3-4-implementation-brief.md`** — a planning document written against
+  v1.10.0 that carries a personal machine path. Verified before ignoring: nothing in the repo
+  references it, so hiding it creates no broken pointer — the failure mode fixed in 1.12.4 and
+  1.12.6. Named explicitly rather than globbed; a `*brief*.md` pattern would also swallow output
+  from `scripts/content_brief.py`.
+  - Worth recording: **all nine features it proposed (F1–F8, S1–S2) have since shipped** — drift
+    monitoring, semantic clustering, content briefs, e-commerce schema, the API tier system, maps
+    intelligence, PDF reports, content-quality tools and headless rendering are all present. It is a
+    record of completed work, not an outstanding plan.
+
 - **FAQ Search Console API sunset — closed as unanswerable** (`references/schema-types.md`). The
   reported August 2026 window was investigated and **can be neither confirmed nor refuted**. It is
   now recorded as a settled position rather than a question awaiting an answer, so nobody re-opens


### PR DESCRIPTION
A planning document written against v1.10.0 that carries a personal machine path — same problem as the existing `.cursor/rules/filesystem-access.mdc` entry, and now sits next to it.

## Checked before ignoring

**Nothing in the repo references it**, so hiding it creates no broken pointer. That's the failure mode fixed in 1.12.4 (removed Google tools) and 1.12.6 (an uncommitted requirements file four scripts pointed at) — ignoring a referenced file would have reintroduced it.

**Named explicitly rather than globbed.** A `*brief*.md` pattern would also swallow output from `scripts/content_brief.py`, which generates content briefs.

Verified after the change: **0 tracked files became ignored**, and nothing untracked remains outside `.cursor/`.

## Worth recording: the brief is already done

All nine features it proposed have since shipped:

| | Feature | Now |
|---|---|---|
| F1 | SEO Drift Monitoring | `drift_monitor.py` + §22 |
| F2 | Semantic Topic Clustering | `topic_cluster.py` + §23 |
| F3 | Content Brief Generation | `content_brief.py` |
| F4 | E-commerce SEO Module | `ecommerce_schema.py` + §24 |
| F5 | Google API Tier System | `google_api_tier.py` |
| F7 | Maps Intelligence | `maps_checker.py` + §25 |
| F8 | Professional PDF Reports | `pdf_template.py`, `pdf_charts.py` |
| S1 | Content Quality Tools | `content_quality.py` |
| S2 | Headless Rendering | `render_page.py` |

**It's a record of completed work, not an outstanding plan** — which is what makes ignoring it safe rather than a way of quietly losing a roadmap. Worth knowing before it disappears from `git status`.

## Verification

- `pytest tests/` — **241 passed**
- `git check-ignore -v` confirms the rule matches
- No tracked file becomes ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)