### PR TITLE
fix: eight defects in the audit scripts, across nine scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 ### Fixed
 
-- **Four crashes, four silent misses and one false Critical.** Three surfaced by running v1.12.6
-  against a live site; the other six were found by probing the sibling scripts with the same page
-  shapes afterwards. All nine survived a green 241-test suite because every one of them needs *real
-  page shapes* to fire — the fixtures in `tests/` are all well-formed single-type schema,
-  single-object blocks and slash-free hrefs. The four that never raised are the more dangerous
-  half: a crash gets noticed, a page silently reported as clean does not.
+- **Three crashes, four silent misses and one false Critical, across nine scripts.** Three
+  surfaced by running v1.12.6 against a live site; the other five were found by probing the sibling
+  scripts with the same page shapes afterwards. All eight survived a green 241-test suite because
+  every one of them needs *real page shapes* to fire — the fixtures in `tests/` are all well-formed
+  single-type schema, single-object blocks and slash-free hrefs. The four that never raised are the
+  more dangerous half: a crash gets noticed, a page silently reported as clean does not.
   - **`broken_links.py` aborted the crawl on the first healthy link.** `check_link()` seeds every
     result with `"redirect": None`, so `.get("redirect", {})` returned `None` — not the `{}` default
     — and chaining `.get("hops", 0)` onto it raised `AttributeError`. The default only applies when
@@ -62,7 +62,7 @@
     over the raw HTML, which never sees the list form: a genuine local business carrying
     `["LocalBusiness", "Store"]` was told **at high severity** to add the schema it already had —
     the worst failure mode of the four, since it is a confident instruction to do the wrong thing.
-  - `tests/test_audit_script_crashes.py` (45 tests) covers all nine. Validated by reintroducing each
+  - `tests/test_audit_script_crashes.py` (45 tests) covers all eight. Validated by reintroducing each
     defect one at a time and confirming the suite catches it — 286 passing, up from 241 — and by
     running the scripts end to end: `parse_html.py`/`validate_schema.py`/`article_seo.py` against a
     fixture carrying an array, a multi-typed node and a retired type; `validate_schema.py` against a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,21 @@
     (`[]`, a bare string) is reported as `not_an_object` rather than dropped in silence. One
     consequence worth knowing: the `Schema Blocks: N` line now counts schema *nodes*, not
     `<script>` tags, on pages that use the array form.
-  - `tests/test_audit_script_crashes.py` (27 tests) covers all five. Validated by reintroducing each
-    defect one at a time and confirming the suite catches it — 268 passing, up from 241 — and by
+  - **The same list `@type`, one layer out, in two consumers that never crashed.**
+    `entity_checker.py` compared the raw value against its entity-type tuple and
+    `generate_report.py` ran `str()` over it before an intersection — so
+    `["LocalBusiness", "Organization"]` and `["NewsArticle", "Article"]` matched nothing and
+    both simply returned empty. A multi-typed `Organization` was reported as having no entity
+    signals at all, and the preferred-sources findings were silently skipped on every
+    multi-typed publisher page. Both now normalise through their own `_type_names()`.
+    `entity_checker.py` stores the *matched* name rather than the list, because
+    `check_nap_consistency()` tests `entity["type"]` for membership and prints it — keeping the
+    list there would have moved the same silent miss one layer further on. These two were found
+    by probing the sibling scripts with array and multi-typed fixtures after the crashes above
+    were fixed; `maps_checker.py`, `ecommerce_schema.py` and `content_brief.py` were probed the
+    same way and already handle both shapes.
+  - `tests/test_audit_script_crashes.py` (35 tests) covers all seven. Validated by reintroducing each
+    defect one at a time and confirming the suite catches it — 276 passing, up from 241 — and by
     running the scripts end to end: `parse_html.py`/`validate_schema.py`/`article_seo.py` against a
     fixture carrying an array, a multi-typed node and a retired type, and `broken_links.py --crawl`
     against a live site, which now completes and reports a genuine 2-hop chain where it previously

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,22 @@
     over the raw HTML, which never sees the list form: a genuine local business carrying
     `["LocalBusiness", "Store"]` was told **at high severity** to add the schema it already had —
     the worst failure mode of the four, since it is a confident instruction to do the wrong thing.
-  - `tests/test_audit_script_crashes.py` (45 tests) covers all eight. Validated by reintroducing each
-    defect one at a time and confirming the suite catches it — 286 passing, up from 241 — and by
+  - **The fixes above are now one implementation, not seven.** Each script had grown its own
+    `_type_names()` / `_is_type()` / `_schema_nodes()` / `_declares_type()` — the same helper
+    written seven times, which is how the original single-shape assumption managed to be fixed in
+    three places and missed in four. New `scripts/jsonld.py` holds `type_names()`, `is_type()`,
+    `nodes()` and `declares_type()`, and all seven consumers delegate to it. Stdlib only:
+    `faq_parity.py` and `validate_schema.py` are regex/json by design and must not acquire a
+    BeautifulSoup dependency through a shared module.
+    - **What deliberately did *not* move**: the retired and no-rich-results sets stay module-level
+      in `validate_schema.py`, `parse_html.py` and `article_seo.py`, pinned to
+      `references/schema-types.md` by `tests/test_schema_status_parity.py` (**D-017**).
+      `jsonld.py` knows about JSON-LD *shapes*; it knows nothing about which types Google retired.
+    - Two tests pin the consolidation per consumer: one asserts each module delegates to the shared
+      `jsonld` (which also catches a script that loses its import in a later edit), the other that
+      no private copy of the helpers has re-grown.
+  - `tests/test_audit_script_crashes.py` (59 tests) covers all eight. Validated by reintroducing each
+    defect one at a time and confirming the suite catches it — 300 passing, up from 241 — and by
     running the scripts end to end: `parse_html.py`/`validate_schema.py`/`article_seo.py` against a
     fixture carrying an array, a multi-typed node and a retired type; `validate_schema.py` against a
     multi-typed `FAQPage` whose answer is absent from the HTML, which now raises the parity finding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ### Fixed
 
-- **Four crashes and one false Critical.** Three surfaced by running v1.12.6 against a live site;
-  the fourth was found while fixing them and is the same defect one shape further out. All five
-  survived a green 241-test suite because every one of them needs *real page shapes* to fire — the
-  fixtures in `tests/` are all well-formed single-type schema, single-object blocks and slash-free
-  hrefs.
+- **Four crashes, four silent misses and one false Critical.** Three surfaced by running v1.12.6
+  against a live site; the other six were found by probing the sibling scripts with the same page
+  shapes afterwards. All nine survived a green 241-test suite because every one of them needs *real
+  page shapes* to fire — the fixtures in `tests/` are all well-formed single-type schema,
+  single-object blocks and slash-free hrefs. The four that never raised are the more dangerous
+  half: a crash gets noticed, a page silently reported as clean does not.
   - **`broken_links.py` aborted the crawl on the first healthy link.** `check_link()` seeds every
     result with `"redirect": None`, so `.get("redirect", {})` returned `None` — not the `{}` default
     — and chaining `.get("hops", 0)` onto it raised `AttributeError`. The default only applies when
@@ -52,12 +53,22 @@
     by probing the sibling scripts with array and multi-typed fixtures after the crashes above
     were fixed; `maps_checker.py`, `ecommerce_schema.py` and `content_brief.py` were probed the
     same way and already handle both shapes.
-  - `tests/test_audit_script_crashes.py` (35 tests) covers all seven. Validated by reintroducing each
-    defect one at a time and confirming the suite catches it — 276 passing, up from 241 — and by
+  - **And two more consumers on the same shape, both louder in their silence.** `faq_parity.py`
+    gated on `get("@type") != "FAQPage"`, so the visible-HTML parity check passed silently on
+    exactly the pages that carry FAQ markup alongside a page type — the ordinary
+    `["WebPage", "FAQPage"]` shape. Because `validate_schema.py`, `parse_html.py` and
+    `article_seo.py` all route their FAQ check through it, one gate disabled the finding in three
+    scripts at once. `local_signals_checker.py` matched `"@type"\s*:\s*"LocalBusiness"` by regex
+    over the raw HTML, which never sees the list form: a genuine local business carrying
+    `["LocalBusiness", "Store"]` was told **at high severity** to add the schema it already had —
+    the worst failure mode of the four, since it is a confident instruction to do the wrong thing.
+  - `tests/test_audit_script_crashes.py` (45 tests) covers all nine. Validated by reintroducing each
+    defect one at a time and confirming the suite catches it — 286 passing, up from 241 — and by
     running the scripts end to end: `parse_html.py`/`validate_schema.py`/`article_seo.py` against a
-    fixture carrying an array, a multi-typed node and a retired type, and `broken_links.py --crawl`
-    against a live site, which now completes and reports a genuine 2-hop chain where it previously
-    raised on the first link.
+    fixture carrying an array, a multi-typed node and a retired type; `validate_schema.py` against a
+    multi-typed `FAQPage` whose answer is absent from the HTML, which now raises the parity finding
+    it used to skip; and `broken_links.py --crawl` against a live site, which now completes and
+    reports a genuine 2-hop chain where it previously raised on the first link.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Three crashes and one false Critical, found by running v1.12.6 against a live site.** All four
+  survived a green 241-test suite because every one of them needs *real page shapes* to fire — the
+  fixtures in `tests/` are all well-formed single-type schema and slash-free hrefs.
+  - **`broken_links.py` aborted the crawl on the first healthy link.** `check_link()` seeds every
+    result with `"redirect": None`, so `.get("redirect", {})` returned `None` — not the `{}` default
+    — and chaining `.get("hops", 0)` onto it raised `AttributeError`. The default only applies when
+    the key is *absent*, and it never is. The expression is now the single helper
+    `is_redirect_chain()`, used at all three call sites, so the trap cannot be reintroduced in one
+    place and missed in the other two.
+  - **`@type` as a list raised `TypeError: unhashable type: 'list'`** in `validate_schema.py`,
+    `parse_html.py` and `article_seo.py` alike — the same line, copied three ways. JSON-LD allows
+    `"@type": ["WebPage", "FAQPage"]`, and testing that list against the retired-types dict dropped
+    the *whole page* from the audit; on the site that surfaced it, `/gallery/` and `/es/galeria/`
+    were reported as having no findings rather than as having failed. A `_type_names()` helper in
+    each script normalises string-or-list, and a retired type anywhere in the list still outranks a
+    no-rich-results one, matching the single-type precedence it replaced. The sets themselves stay
+    module-level and CI-pinned per D-017 — no shared module, no new drift surface.
+  - **`internal_links.py` reported 94 links-to-redirects that were not in the HTML.** Link
+    extraction stripped trailing slashes, the crawler then requested a URL the page never linked to,
+    and the site's canonical 301 back to `/path/` was recorded as an internal link pointing to a
+    redirect — a round trip this script's own normalisation created. Reported and crawled URLs now
+    keep the href's own slash; de-duplication moved to a slash-insensitive `_dedup_key()`, so
+    `/gallery` and `/gallery/` still count once and are no longer fetched twice. A link that
+    genuinely points at a redirect is still flagged.
+  - `tests/test_audit_script_crashes.py` (18 tests) covers all four. Validated by reintroducing each
+    defect one at a time and confirming the suite catches it — 259 passing, up from 241.
+
 ### Changed
 
 - **`.gitignore` covers `tier-3-4-implementation-brief.md`** — a planning document written against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### Fixed
 
-- **Three crashes and one false Critical, found by running v1.12.6 against a live site.** All four
+- **Four crashes and one false Critical.** Three surfaced by running v1.12.6 against a live site;
+  the fourth was found while fixing them and is the same defect one shape further out. All five
   survived a green 241-test suite because every one of them needs *real page shapes* to fire — the
-  fixtures in `tests/` are all well-formed single-type schema and slash-free hrefs.
+  fixtures in `tests/` are all well-formed single-type schema, single-object blocks and slash-free
+  hrefs.
   - **`broken_links.py` aborted the crawl on the first healthy link.** `check_link()` seeds every
     result with `"redirect": None`, so `.get("redirect", {})` returned `None` — not the `{}` default
     — and chaining `.get("hops", 0)` onto it raised `AttributeError`. The default only applies when
@@ -28,8 +30,21 @@
     keep the href's own slash; de-duplication moved to a slash-insensitive `_dedup_key()`, so
     `/gallery` and `/gallery/` still count once and are no longer fetched twice. A link that
     genuinely points at a redirect is still flagged.
-  - `tests/test_audit_script_crashes.py` (18 tests) covers all four. Validated by reintroducing each
-    defect one at a time and confirming the suite catches it — 259 passing, up from 241.
+  - **A top-level JSON-LD *array* crashed `parse_html.py` and `article_seo.py`** with the same
+    `AttributeError` — both called `.get()` straight on `json.loads()` output, and
+    `[{...}, {...}]` in one `<script>` block is valid JSON-LD that several CMSes emit.
+    `validate_schema.py` already branched on `isinstance(data, list)` and was the model. Each array
+    member is now reported as its own block, so a retired type buried in an array is flagged
+    instead of taking the page down with it; a block of valid JSON carrying no objects at all
+    (`[]`, a bare string) is reported as `not_an_object` rather than dropped in silence. One
+    consequence worth knowing: the `Schema Blocks: N` line now counts schema *nodes*, not
+    `<script>` tags, on pages that use the array form.
+  - `tests/test_audit_script_crashes.py` (27 tests) covers all five. Validated by reintroducing each
+    defect one at a time and confirming the suite catches it — 268 passing, up from 241 — and by
+    running the scripts end to end: `parse_html.py`/`validate_schema.py`/`article_seo.py` against a
+    fixture carrying an array, a multi-typed node and a retired type, and `broken_links.py --crawl`
+    against a live site, which now completes and reports a genuine 2-hop chain where it previously
+    raised on the first link.
 
 ### Changed
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/article_seo.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/article_seo.py
@@ -275,6 +275,57 @@ def extract_content(soup: BeautifulSoup, cms: str) -> dict:
 # JSON-LD structured data extraction
 # ---------------------------------------------------------------------------
 
+def _schema_nodes(data) -> list:
+    """Every schema node carried by one JSON-LD block.
+
+    A block may hold a single object or a top-level array of objects — both are
+    valid JSON-LD and both are emitted by real CMSes. Calling .get() straight on
+    the array form raised AttributeError, killing the parse for the whole page.
+    Each member is reported as its own block so a retired type buried in an
+    array is still flagged.
+    """
+    if isinstance(data, dict):
+        return [data]
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    return []
+
+
+def _describe_schema_node(node: dict, page_text: str) -> dict:
+    """Status, note and FAQ parity for a single JSON-LD node."""
+    schema_type = node.get("@type", "Unknown")
+    status = "active"
+    note = ""
+
+    # @type may be a list; a retired type anywhere in it wins, matching the
+    # single-type precedence this replaced.
+    names = _type_names(schema_type)
+    retired = next((n for n in names if n in DEPRECATED_SCHEMA), None)
+    no_rich = next((n for n in names if n in NO_RICH_RESULTS), None)
+
+    if retired:
+        status = "deprecated"
+        note = f"{retired} is retired — Google no longer processes this type. Remove or replace."
+    elif no_rich:
+        status = "no_rich_results"
+        note = f"{no_rich} no longer produces a Google rich result, but the schema is still valid. Keep it."
+
+    return {
+        "@type": schema_type,
+        # FAQ answer text in JSON-LD but not in the rendered HTML is
+        # invisible to users and AI crawlers (procedures/03 step 4).
+        "faq_answers_missing_from_html": (
+            faq_parity.missing_answers(node, page_text) if page_text else []
+        ),
+        "@context": node.get("@context", ""),
+        "status": status,
+        "note": note,
+        "has_context": bool(node.get("@context")),
+        "has_type": bool(node.get("@type")),
+        "raw": node,
+    }
+
+
 def extract_structured_data(soup: BeautifulSoup, page_text: str = "") -> list:
     """
     Extract and parse all <script type="application/ld+json"> blocks.
@@ -289,37 +340,15 @@ def extract_structured_data(soup: BeautifulSoup, page_text: str = "") -> list:
             blocks.append({"error": "invalid_json", "raw_snippet": raw[:120]})
             continue
 
-        schema_type = data.get("@type", "Unknown")
-        status = "active"
-        note = ""
+        nodes = _schema_nodes(data)
+        if not nodes:
+            # Valid JSON, but nothing object-shaped in it — say so rather than
+            # dropping the block on the floor.
+            blocks.append({"error": "not_an_object", "raw_snippet": raw[:120]})
+            continue
 
-        # @type may be a list; a retired type anywhere in it wins, matching the
-        # single-type precedence this replaced.
-        names = _type_names(schema_type)
-        retired = next((n for n in names if n in DEPRECATED_SCHEMA), None)
-        no_rich = next((n for n in names if n in NO_RICH_RESULTS), None)
-
-        if retired:
-            status = "deprecated"
-            note = f"{retired} is retired — Google no longer processes this type. Remove or replace."
-        elif no_rich:
-            status = "no_rich_results"
-            note = f"{no_rich} no longer produces a Google rich result, but the schema is still valid. Keep it."
-
-        # FAQ answer text in JSON-LD but not in the rendered HTML is
-        # invisible to users and AI crawlers (procedures/03 step 4).
-        missing_faq = faq_parity.missing_answers(data, page_text) if page_text else []
-
-        blocks.append({
-            "@type": schema_type,
-            "faq_answers_missing_from_html": missing_faq,
-            "@context": data.get("@context", ""),
-            "status": status,
-            "note": note,
-            "has_context": bool(data.get("@context")),
-            "has_type": bool(data.get("@type")),
-            "raw": data,
-        })
+        for node in nodes:
+            blocks.append(_describe_schema_node(node, page_text))
 
     return blocks
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/article_seo.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/article_seo.py
@@ -75,6 +75,21 @@ NO_RICH_RESULTS = {"HowTo", "FAQPage", "Quiz", "Dataset"}
 # Fetch
 # ---------------------------------------------------------------------------
 
+def _type_names(value) -> list:
+    """Return the @type value as a list of type strings.
+
+    JSON-LD allows @type to be a single string or a list — a multi-typed node
+    such as ["WebPage", "FAQPage"] is valid and common. Testing the raw value
+    with `value in DEPRECATED_SCHEMA` raised TypeError: unhashable type: 'list'
+    on the list form.
+    """
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [v for v in value if isinstance(v, str)]
+    return []
+
+
 def fetch_html(url: str) -> str:
     """Fetch raw HTML from a URL with a realistic browser user-agent."""
     try:
@@ -278,12 +293,18 @@ def extract_structured_data(soup: BeautifulSoup, page_text: str = "") -> list:
         status = "active"
         note = ""
 
-        if schema_type in DEPRECATED_SCHEMA:
+        # @type may be a list; a retired type anywhere in it wins, matching the
+        # single-type precedence this replaced.
+        names = _type_names(schema_type)
+        retired = next((n for n in names if n in DEPRECATED_SCHEMA), None)
+        no_rich = next((n for n in names if n in NO_RICH_RESULTS), None)
+
+        if retired:
             status = "deprecated"
-            note = f"{schema_type} is retired — Google no longer processes this type. Remove or replace."
-        elif schema_type in NO_RICH_RESULTS:
+            note = f"{retired} is retired — Google no longer processes this type. Remove or replace."
+        elif no_rich:
             status = "no_rich_results"
-            note = f"{schema_type} no longer produces a Google rich result, but the schema is still valid. Keep it."
+            note = f"{no_rich} no longer produces a Google rich result, but the schema is still valid. Keep it."
 
         # FAQ answer text in JSON-LD but not in the rendered HTML is
         # invisible to users and AI crawlers (procedures/03 step 4).

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/article_seo.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/article_seo.py
@@ -22,6 +22,7 @@ import argparse
 import json
 
 import faq_parity
+import jsonld
 import re
 import sys
 import math
@@ -74,21 +75,6 @@ NO_RICH_RESULTS = {"HowTo", "FAQPage", "Quiz", "Dataset"}
 # ---------------------------------------------------------------------------
 # Fetch
 # ---------------------------------------------------------------------------
-
-def _type_names(value) -> list:
-    """Return the @type value as a list of type strings.
-
-    JSON-LD allows @type to be a single string or a list — a multi-typed node
-    such as ["WebPage", "FAQPage"] is valid and common. Testing the raw value
-    with `value in DEPRECATED_SCHEMA` raised TypeError: unhashable type: 'list'
-    on the list form.
-    """
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, list):
-        return [v for v in value if isinstance(v, str)]
-    return []
-
 
 def fetch_html(url: str) -> str:
     """Fetch raw HTML from a URL with a realistic browser user-agent."""
@@ -275,22 +261,6 @@ def extract_content(soup: BeautifulSoup, cms: str) -> dict:
 # JSON-LD structured data extraction
 # ---------------------------------------------------------------------------
 
-def _schema_nodes(data) -> list:
-    """Every schema node carried by one JSON-LD block.
-
-    A block may hold a single object or a top-level array of objects — both are
-    valid JSON-LD and both are emitted by real CMSes. Calling .get() straight on
-    the array form raised AttributeError, killing the parse for the whole page.
-    Each member is reported as its own block so a retired type buried in an
-    array is still flagged.
-    """
-    if isinstance(data, dict):
-        return [data]
-    if isinstance(data, list):
-        return [item for item in data if isinstance(item, dict)]
-    return []
-
-
 def _describe_schema_node(node: dict, page_text: str) -> dict:
     """Status, note and FAQ parity for a single JSON-LD node."""
     schema_type = node.get("@type", "Unknown")
@@ -299,7 +269,7 @@ def _describe_schema_node(node: dict, page_text: str) -> dict:
 
     # @type may be a list; a retired type anywhere in it wins, matching the
     # single-type precedence this replaced.
-    names = _type_names(schema_type)
+    names = jsonld.type_names(schema_type)
     retired = next((n for n in names if n in DEPRECATED_SCHEMA), None)
     no_rich = next((n for n in names if n in NO_RICH_RESULTS), None)
 
@@ -340,7 +310,7 @@ def extract_structured_data(soup: BeautifulSoup, page_text: str = "") -> list:
             blocks.append({"error": "invalid_json", "raw_snippet": raw[:120]})
             continue
 
-        nodes = _schema_nodes(data)
+        nodes = jsonld.nodes(data)
         if not nodes:
             # Valid JSON, but nothing object-shaped in it — say so rather than
             # dropping the block on the floor.

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/broken_links.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/broken_links.py
@@ -70,6 +70,17 @@ def extract_links(html: str, base_url: str) -> list:
     return links
 
 
+def is_redirect_chain(link_result: dict) -> bool:
+    """True when a checked link travelled through more than one redirect hop.
+
+    `check_link` initialises "redirect" to None on every result, so the {}
+    default of `.get("redirect", {})` was never reached: the call returned None
+    and chaining `.get("hops", 0)` onto it raised AttributeError on the first
+    link that was not redirected.
+    """
+    return (link_result.get("redirect") or {}).get("hops", 0) > 1
+
+
 def check_link(link: dict, timeout: int = 10, detect_soft_404: bool = True) -> dict:
     """Check a single link's HTTP status, including soft 404 detection."""
     url = link["url"]
@@ -225,8 +236,7 @@ def check_broken_links(url: str, internal_only: bool = False,
             f"⚠️ {len(result['timeout'])} link(s) timed out"
         )
     if result["redirected"]:
-        chains = [l for l in result["redirected"]
-                  if l.get("redirect", {}).get("hops", 0) > 1]
+        chains = [l for l in result["redirected"] if is_redirect_chain(l)]
         if chains:
             result["issues"].append(
                 f"⚠️ {len(chains)} redirect chain(s) detected (>1 hop)"
@@ -312,7 +322,7 @@ def crawl_broken_links(start_url: str, max_depth: int = 2, max_pages: int = 50,
                 elif status and status >= 400:
                     all_broken.append(link_result)
                     broken_by_target[link_result["url"]].append(page_url)
-                elif link_result.get("redirect", {}).get("hops", 0) > 1:
+                elif is_redirect_chain(link_result):
                     all_chains.append(link_result)
                 else:
                     healthy_count += 1
@@ -441,8 +451,7 @@ def main():
 
     redirected = result.get("redirected", result.get("redirected_chains", []))
     if redirected:
-        chains = [l for l in redirected
-                  if l.get("redirect", {}).get("hops", 0) > 1]
+        chains = [l for l in redirected if is_redirect_chain(l)]
         if chains:
             print(f"\n⚠️ Redirect Chains (>1 hop):")
             for link in chains:

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/entity_checker.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/entity_checker.py
@@ -21,6 +21,8 @@ import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from urllib.parse import urlparse
 
+import jsonld
+
 try:
     from bs4 import BeautifulSoup
 except ImportError:
@@ -69,21 +71,6 @@ ENTITY_TYPES = (
 )
 
 
-def _type_names(value) -> list:
-    """Return the @type value as a list of type strings.
-
-    JSON-LD allows @type to be a single string or a list. A multi-typed node
-    such as ["LocalBusiness", "Organization"] is valid and common; comparing
-    the raw value against ENTITY_TYPES matched nothing, so the entity was
-    dropped without error and the page reported no entity signals at all.
-    """
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, list):
-        return [v for v in value if isinstance(v, str)]
-    return []
-
-
 def extract_entities_from_schema(soup: BeautifulSoup) -> list:
     """Extract Organization/Person entities and their sameAs from JSON-LD."""
     entities = []
@@ -110,7 +97,7 @@ def extract_entities_from_schema(soup: BeautifulSoup) -> list:
             # entity["type"] for membership and prints it, so a list here
             # would reintroduce the same silent miss one layer further on.
             entity_type = next(
-                (n for n in _type_names(item.get("@type")) if n in ENTITY_TYPES),
+                (n for n in jsonld.type_names(item.get("@type")) if n in ENTITY_TYPES),
                 None,
             )
             if entity_type:

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/entity_checker.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/entity_checker.py
@@ -63,6 +63,27 @@ def fetch_html(url: str, timeout: int = 12) -> str:
 # Schema extraction
 # ---------------------------------------------------------------------------
 
+ENTITY_TYPES = (
+    "Organization", "Person", "Corporation", "LocalBusiness", "Brand",
+    "MedicalOrganization", "EducationalOrganization", "GovernmentOrganization",
+)
+
+
+def _type_names(value) -> list:
+    """Return the @type value as a list of type strings.
+
+    JSON-LD allows @type to be a single string or a list. A multi-typed node
+    such as ["LocalBusiness", "Organization"] is valid and common; comparing
+    the raw value against ENTITY_TYPES matched nothing, so the entity was
+    dropped without error and the page reported no entity signals at all.
+    """
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [v for v in value if isinstance(v, str)]
+    return []
+
+
 def extract_entities_from_schema(soup: BeautifulSoup) -> list:
     """Extract Organization/Person entities and their sameAs from JSON-LD."""
     entities = []
@@ -85,13 +106,16 @@ def extract_entities_from_schema(soup: BeautifulSoup) -> list:
         for item in items:
             if not isinstance(item, dict):
                 continue
-            schema_type = item.get("@type", "")
-            # Look for entity types
-            if schema_type in ("Organization", "Person", "Corporation",
-                               "LocalBusiness", "Brand", "MedicalOrganization",
-                               "EducationalOrganization", "GovernmentOrganization"):
+            # The matched name, not the raw @type: downstream code tests
+            # entity["type"] for membership and prints it, so a list here
+            # would reintroduce the same silent miss one layer further on.
+            entity_type = next(
+                (n for n in _type_names(item.get("@type")) if n in ENTITY_TYPES),
+                None,
+            )
+            if entity_type:
                 entities.append({
-                    "type": schema_type,
+                    "type": entity_type,
                     "name": item.get("name", ""),
                     "url": item.get("url", ""),
                     "sameAs": item.get("sameAs", []),

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/faq_parity.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/faq_parity.py
@@ -53,11 +53,25 @@ def visible_text(html_content: str) -> str:
     return normalize(_SCRIPT_STYLE_RE.sub(" ", html_content or ""))
 
 
+def _is_type(node, wanted: str) -> bool:
+    """True when a node declares `wanted`, as a string or inside a list @type.
+
+    JSON-LD allows @type to be a list, and `["WebPage", "FAQPage"]` is the
+    ordinary shape for a page that is both. Comparing the raw value with `!=`
+    skipped those nodes, so parity silently passed on exactly the pages that
+    carry FAQ markup alongside a page type.
+    """
+    if not isinstance(node, dict):
+        return False
+    value = node.get("@type")
+    if isinstance(value, list):
+        return wanted in value
+    return value == wanted
+
+
 def _iter_questions(schema_obj):
     """Yield Question nodes from a FAQPage `mainEntity`, list or single."""
-    if not isinstance(schema_obj, dict):
-        return
-    if schema_obj.get("@type") != "FAQPage":
+    if not _is_type(schema_obj, "FAQPage"):
         return
     entity = schema_obj.get("mainEntity")
     if isinstance(entity, dict):
@@ -65,7 +79,7 @@ def _iter_questions(schema_obj):
     if not isinstance(entity, list):
         return
     for node in entity:
-        if isinstance(node, dict) and node.get("@type") == "Question":
+        if _is_type(node, "Question"):
             yield node
 
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/faq_parity.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/faq_parity.py
@@ -17,6 +17,8 @@ that the rendered DOM does not, so raw equality reports false misses.
 
 import html
 import re
+
+import jsonld
 from typing import List
 
 # Answers shorter than this are skipped: a handful of characters can appear
@@ -53,25 +55,9 @@ def visible_text(html_content: str) -> str:
     return normalize(_SCRIPT_STYLE_RE.sub(" ", html_content or ""))
 
 
-def _is_type(node, wanted: str) -> bool:
-    """True when a node declares `wanted`, as a string or inside a list @type.
-
-    JSON-LD allows @type to be a list, and `["WebPage", "FAQPage"]` is the
-    ordinary shape for a page that is both. Comparing the raw value with `!=`
-    skipped those nodes, so parity silently passed on exactly the pages that
-    carry FAQ markup alongside a page type.
-    """
-    if not isinstance(node, dict):
-        return False
-    value = node.get("@type")
-    if isinstance(value, list):
-        return wanted in value
-    return value == wanted
-
-
 def _iter_questions(schema_obj):
     """Yield Question nodes from a FAQPage `mainEntity`, list or single."""
-    if not _is_type(schema_obj, "FAQPage"):
+    if not jsonld.is_type(schema_obj, "FAQPage"):
         return
     entity = schema_obj.get("mainEntity")
     if isinstance(entity, dict):
@@ -79,7 +65,7 @@ def _iter_questions(schema_obj):
     if not isinstance(entity, list):
         return
     for node in entity:
-        if _is_type(node, "Question"):
+        if jsonld.is_type(node, "Question"):
             yield node
 
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/generate_report.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/generate_report.py
@@ -28,6 +28,8 @@ from typing import Optional
 import re
 import subprocess
 import sys
+
+import jsonld
 import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -208,20 +210,6 @@ def _platform_hint(primary: str, area: str) -> str:
     return platform_map.get(primary, fallback).get(area, fallback.get(area, ""))
 
 
-def _type_names(value) -> list:
-    """Return the @type value as a list of type strings.
-
-    JSON-LD allows @type to be a single string or a list, and parse_html.py
-    passes the value through untouched, so the schema blocks this report reads
-    carry both shapes.
-    """
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, list):
-        return [v for v in value if isinstance(v, str)]
-    return []
-
-
 def build_environment_fixes(data: dict) -> list:
     """Build actionable issue fixes tailored to detected environment."""
     env = data.get("environment", {})
@@ -309,14 +297,14 @@ def build_environment_fixes(data: dict) -> list:
     # Raising it on a site that never appears in Top Stories is noise, so gate the
     # finding on a publisher signal rather than reporting it everywhere.
     ps = data["sections"].get("preferred_sources", {})
-    # Flattened via _type_names: str() on a list @type produced
+    # Flattened via jsonld.type_names: str() on a list @type produced
     # "['NewsArticle', 'Article']", which matches nothing below, so the
     # preferred-sources findings vanished on every multi-typed publisher page.
     schema_types = {
         name
         for s in (op.get("schema") or [])
         if isinstance(s, dict)
-        for name in _type_names(s.get("@type"))
+        for name in jsonld.type_names(s.get("@type"))
     }
     looks_like_publisher = bool(schema_types & {"NewsArticle", "NewsMediaOrganization", "LiveBlogPosting"})
     if ps and not ps.get("error") and looks_like_publisher:

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/generate_report.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/generate_report.py
@@ -208,6 +208,20 @@ def _platform_hint(primary: str, area: str) -> str:
     return platform_map.get(primary, fallback).get(area, fallback.get(area, ""))
 
 
+def _type_names(value) -> list:
+    """Return the @type value as a list of type strings.
+
+    JSON-LD allows @type to be a single string or a list, and parse_html.py
+    passes the value through untouched, so the schema blocks this report reads
+    carry both shapes.
+    """
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [v for v in value if isinstance(v, str)]
+    return []
+
+
 def build_environment_fixes(data: dict) -> list:
     """Build actionable issue fixes tailored to detected environment."""
     env = data.get("environment", {})
@@ -295,8 +309,14 @@ def build_environment_fixes(data: dict) -> list:
     # Raising it on a site that never appears in Top Stories is noise, so gate the
     # finding on a publisher signal rather than reporting it everywhere.
     ps = data["sections"].get("preferred_sources", {})
+    # Flattened via _type_names: str() on a list @type produced
+    # "['NewsArticle', 'Article']", which matches nothing below, so the
+    # preferred-sources findings vanished on every multi-typed publisher page.
     schema_types = {
-        str(s.get("@type", "")) for s in (op.get("schema") or []) if isinstance(s, dict)
+        name
+        for s in (op.get("schema") or [])
+        if isinstance(s, dict)
+        for name in _type_names(s.get("@type"))
     }
     looks_like_publisher = bool(schema_types & {"NewsArticle", "NewsMediaOrganization", "LiveBlogPosting"})
     if ps and not ps.get("error") and looks_like_publisher:

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/internal_links.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/internal_links.py
@@ -33,6 +33,15 @@ except ImportError:
 HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; UltimateSEO/1.8)"}
 
 
+def _dedup_key(url: str) -> str:
+    """Slash-insensitive identity for a URL.
+
+    /gallery and /gallery/ are the same page for counting and de-duplication,
+    but only one of them is what the page actually linked to.
+    """
+    return url.rstrip("/") or url
+
+
 def extract_internal_links(html: str, page_url: str, domain: str) -> list:
     """Extract internal links from HTML."""
     soup = BeautifulSoup(html, "html.parser")
@@ -51,20 +60,25 @@ def extract_internal_links(html: str, page_url: str, domain: str) -> list:
         if parsed.netloc != domain:
             continue
 
-        normalized = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
-        if parsed.path in ("", "/"):
-            normalized = f"{parsed.scheme}://{parsed.netloc}"
-        elif normalized.endswith("/"):
-            normalized = normalized.rstrip("/")
+        # Keep the href's own trailing slash. Stripping it made the crawler
+        # request a URL the page never linked to; a site that canonicalises to
+        # /path/ then 301s straight back, and that round trip — created by this
+        # script's own normalisation, not by the HTML — was reported as
+        # "internal link points to a redirect URL". De-duplication stays
+        # slash-insensitive so /gallery and /gallery/ still count once.
+        target = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+        if parsed.path == "":
+            target = f"{parsed.scheme}://{parsed.netloc}/"
 
-        if normalized in seen:
+        key = _dedup_key(target)
+        if key in seen:
             continue
-        seen.add(normalized)
+        seen.add(key)
 
         anchor_text = tag.get_text(strip=True)[:80] or "[no text]"
         nofollow = "nofollow" in (tag.get("rel", []) or [])
         links.append({
-            "url": normalized,
+            "url": target,
             "anchor_text": anchor_text,
             "nofollow": nofollow,
             "source": page_url,
@@ -119,6 +133,7 @@ def crawl_site(start_url: str, max_depth: int = 2, max_pages: int = 50,
 
     # BFS crawl
     visited = set()
+    visited_keys = set()  # slash-insensitive, so /a and /a/ are not fetched twice
     queue = [(start_url, 0)]  # (url, depth)
     all_links = []
     page_link_counts = {}
@@ -154,8 +169,9 @@ def crawl_site(start_url: str, max_depth: int = 2, max_pages: int = 50,
         batch = []
         while queue and len(batch) < max_workers:
             url, depth = queue.pop(0)
-            if url in visited or depth > max_depth:
+            if _dedup_key(url) in visited_keys or depth > max_depth:
                 continue
+            visited_keys.add(_dedup_key(url))
             visited.add(url)
             batch.append((url, depth))
 
@@ -202,7 +218,7 @@ def crawl_site(start_url: str, max_depth: int = 2, max_pages: int = 50,
                     if link["nofollow"]:
                         result["nofollow_links"].append(link)
 
-                    if link["url"] not in visited and depth + 1 <= max_depth:
+                    if _dedup_key(link["url"]) not in visited_keys and depth + 1 <= max_depth:
                         queue.append((link["url"], depth + 1))
 
     for link in all_links:

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/jsonld.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/jsonld.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Shape-normalising helpers for JSON-LD.
+
+`@type` may be a string or a list, and one `<script type="application/ld+json">`
+block may hold a single object or a top-level array of them. Both shapes are
+valid, both appear on real sites, and every audit script that assumed the single
+form failed on the other — some by raising `TypeError`/`AttributeError`, the
+more dangerous ones by silently reporting nothing and passing the page as clean.
+
+Each script had grown its own copy of the same fix (`_type_names`, `_is_type`,
+`_declares_type`, `_schema_nodes`). This is the one implementation they share,
+so the next shape that needs handling is handled once.
+
+Deliberately dependency-free, stdlib only: `faq_parity.py` and
+`validate_schema.py` are regex/json by design and must not acquire a
+BeautifulSoup dependency through the back door.
+
+Note on scope: this module knows about JSON-LD *shapes* only. Which types are
+retired or no longer produce rich results stays in each script as a
+module-level constant, pinned to `references/schema-types.md` by
+`tests/test_schema_status_parity.py` (decision D-017).
+"""
+
+import re
+from typing import List
+
+
+def type_names(value) -> List[str]:
+    """Return an `@type` value as a list of type strings.
+
+    Accepts the string form, the list form, and anything else (returns empty).
+    Non-string members of a list are dropped rather than coerced — an `@type`
+    of `["Article", {"@id": "..."}]` yields `["Article"]`.
+    """
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [v for v in value if isinstance(v, str)]
+    return []
+
+
+def is_type(node, wanted: str) -> bool:
+    """True when `node` declares `wanted`, as a string or inside a list `@type`.
+
+    `["WebPage", "FAQPage"]` is the ordinary shape for a page that is both, so
+    an `!=` comparison against the raw value skips exactly the pages that carry
+    the markup being looked for.
+    """
+    if not isinstance(node, dict):
+        return False
+    return wanted in type_names(node.get("@type"))
+
+
+def nodes(data) -> list:
+    """Every schema node carried by one parsed JSON-LD block.
+
+    A block may hold a single object or a top-level array of objects. Calling
+    `.get()` straight on the array form raises `AttributeError` and kills the
+    parse for the whole page.
+    """
+    if isinstance(data, dict):
+        return [data]
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    return []
+
+
+def declares_type(html: str, wanted: str) -> bool:
+    """True when raw HTML declares `wanted` as a JSON-LD `@type`, either shape.
+
+    Matches `"@type": "LocalBusiness"` and `"@type": ["LocalBusiness", "Store"]`.
+    For callers that scan raw HTML rather than parsed JSON; prefer `is_type()`
+    where a parsed node is available.
+    """
+    escaped = re.escape(wanted)
+    pattern = r'"@type"\s*:\s*(?:"%s"|\[[^\]]*"%s")' % (escaped, escaped)
+    return bool(re.search(pattern, html or "", re.I))

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/local_signals_checker.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/local_signals_checker.py
@@ -24,6 +24,18 @@ except ImportError:
 USER_AGENT = "Mozilla/5.0 (compatible; UltimateSEO-Local/1.8)"
 
 
+def _declares_type(html: str, wanted: str) -> bool:
+    """True when the raw HTML declares `wanted` as a JSON-LD @type.
+
+    Matches both shapes: `"@type": "LocalBusiness"` and the list form
+    `"@type": ["LocalBusiness", "Store"]`. The string-only pattern this
+    replaced missed multi-typed nodes, so a genuine local business was told —
+    at high severity — to add the schema it already had.
+    """
+    pattern = r'"@type"\s*:\s*(?:"%s"|\[[^\]]*"%s")' % (re.escape(wanted), re.escape(wanted))
+    return bool(re.search(pattern, html, re.I))
+
+
 def check_local_signals(url: str) -> dict:
     parsed = urlparse(url)
     if not parsed.scheme:
@@ -43,9 +55,9 @@ def check_local_signals(url: str) -> dict:
     except Exception as e:
         return {"error": str(e), "url": url}
 
-    lb = bool(re.search(r'"@type"\s*:\s*"LocalBusiness"', html, re.I))
-    org = bool(re.search(r'"@type"\s*:\s*"Organization"', html, re.I))
-    website = bool(re.search(r'"@type"\s*:\s*"WebSite"', html, re.I))
+    lb = _declares_type(html, "LocalBusiness")
+    org = _declares_type(html, "Organization")
+    website = _declares_type(html, "WebSite")
     tel = len(re.findall(r'href=["\']tel:', html, re.I))
     mail = len(re.findall(r'href=["\']mailto:', html, re.I))
     street = bool(

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/local_signals_checker.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/local_signals_checker.py
@@ -15,6 +15,8 @@ import re
 import sys
 from urllib.parse import urlparse
 
+import jsonld
+
 try:
     import requests
 except ImportError:
@@ -22,18 +24,6 @@ except ImportError:
     sys.exit(1)
 
 USER_AGENT = "Mozilla/5.0 (compatible; UltimateSEO-Local/1.8)"
-
-
-def _declares_type(html: str, wanted: str) -> bool:
-    """True when the raw HTML declares `wanted` as a JSON-LD @type.
-
-    Matches both shapes: `"@type": "LocalBusiness"` and the list form
-    `"@type": ["LocalBusiness", "Store"]`. The string-only pattern this
-    replaced missed multi-typed nodes, so a genuine local business was told —
-    at high severity — to add the schema it already had.
-    """
-    pattern = r'"@type"\s*:\s*(?:"%s"|\[[^\]]*"%s")' % (re.escape(wanted), re.escape(wanted))
-    return bool(re.search(pattern, html, re.I))
 
 
 def check_local_signals(url: str) -> dict:
@@ -55,9 +45,9 @@ def check_local_signals(url: str) -> dict:
     except Exception as e:
         return {"error": str(e), "url": url}
 
-    lb = _declares_type(html, "LocalBusiness")
-    org = _declares_type(html, "Organization")
-    website = _declares_type(html, "WebSite")
+    lb = jsonld.declares_type(html, "LocalBusiness")
+    org = jsonld.declares_type(html, "Organization")
+    website = jsonld.declares_type(html, "WebSite")
     tel = len(re.findall(r'href=["\']tel:', html, re.I))
     mail = len(re.findall(r'href=["\']mailto:', html, re.I))
     street = bool(

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/parse_html.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/parse_html.py
@@ -16,6 +16,7 @@ from typing import Optional
 from urllib.parse import urljoin, urlparse
 
 import faq_parity
+import jsonld
 
 # Module-level so tests/test_schema_status_parity.py can check these against
 # the tables in references/schema-types.md.
@@ -36,37 +37,6 @@ except ImportError:
     sys.exit(1)
 
 
-def _type_names(value) -> list:
-    """Return the @type value as a list of type strings.
-
-    JSON-LD allows @type to be a single string or a list — a multi-typed node
-    such as ["WebPage", "FAQPage"] is valid and common. Testing the raw value
-    with `value in DEPRECATED_SCHEMA` raised TypeError: unhashable type: 'list'
-    on the list form.
-    """
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, list):
-        return [v for v in value if isinstance(v, str)]
-    return []
-
-
-def _schema_nodes(data) -> list:
-    """Every schema node carried by one JSON-LD block.
-
-    A block may hold a single object or a top-level array of objects — both are
-    valid JSON-LD and both are emitted by real CMSes. Calling .get() straight on
-    the array form raised AttributeError, killing the parse for the whole page.
-    Each member is reported as its own block so a retired type buried in an
-    array is still flagged.
-    """
-    if isinstance(data, dict):
-        return [data]
-    if isinstance(data, list):
-        return [item for item in data if isinstance(item, dict)]
-    return []
-
-
 def _describe_schema_node(node: dict, page_text: str) -> dict:
     """Status, note and FAQ parity for a single JSON-LD node."""
     schema_type = node.get("@type", "Unknown")
@@ -75,7 +45,7 @@ def _describe_schema_node(node: dict, page_text: str) -> dict:
 
     # @type may be a list; a retired type anywhere in it wins, matching the
     # single-type precedence this replaced.
-    names = _type_names(schema_type)
+    names = jsonld.type_names(schema_type)
     retired = next((n for n in names if n in DEPRECATED_SCHEMA), None)
     no_rich = next((n for n in names if n in NO_RICH_RESULTS), None)
 
@@ -299,7 +269,7 @@ def parse_html(html: str, base_url: Optional[str] = None) -> dict:
             })
             continue
 
-        nodes = _schema_nodes(schema_data)
+        nodes = jsonld.nodes(schema_data)
         if not nodes:
             # Valid JSON, but nothing object-shaped in it — say so rather than
             # dropping the block on the floor.

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/parse_html.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/parse_html.py
@@ -51,6 +51,55 @@ def _type_names(value) -> list:
     return []
 
 
+def _schema_nodes(data) -> list:
+    """Every schema node carried by one JSON-LD block.
+
+    A block may hold a single object or a top-level array of objects — both are
+    valid JSON-LD and both are emitted by real CMSes. Calling .get() straight on
+    the array form raised AttributeError, killing the parse for the whole page.
+    Each member is reported as its own block so a retired type buried in an
+    array is still flagged.
+    """
+    if isinstance(data, dict):
+        return [data]
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    return []
+
+
+def _describe_schema_node(node: dict, page_text: str) -> dict:
+    """Status, note and FAQ parity for a single JSON-LD node."""
+    schema_type = node.get("@type", "Unknown")
+    status = "active"
+    note = ""
+
+    # @type may be a list; a retired type anywhere in it wins, matching the
+    # single-type precedence this replaced.
+    names = _type_names(schema_type)
+    retired = next((n for n in names if n in DEPRECATED_SCHEMA), None)
+    no_rich = next((n for n in names if n in NO_RICH_RESULTS), None)
+
+    if retired:
+        status = "deprecated"
+        note = f"{retired} is retired — Google no longer processes this type. Remove or replace."
+    elif no_rich:
+        status = "no_rich_results"
+        note = f"{no_rich} no longer produces a Google rich result, but the schema is still valid. Keep it."
+
+    return {
+        "@type": schema_type,
+        # FAQ answer text in JSON-LD but not in the rendered HTML is
+        # invisible to users and AI crawlers (procedures/03 step 4).
+        "faq_answers_missing_from_html": faq_parity.missing_answers(node, page_text),
+        "@context": node.get("@context", ""),
+        "status": status,
+        "note": note,
+        "has_context": bool(node.get("@context")),
+        "has_type": bool(node.get("@type")),
+        "raw": node,
+    }
+
+
 def _link_rel_has_canonical(rel) -> bool:
     if rel is None:
         return False
@@ -250,37 +299,18 @@ def parse_html(html: str, base_url: Optional[str] = None) -> dict:
             })
             continue
 
-        schema_type = schema_data.get("@type", "Unknown")
-        status = "active"
-        note = ""
+        nodes = _schema_nodes(schema_data)
+        if not nodes:
+            # Valid JSON, but nothing object-shaped in it — say so rather than
+            # dropping the block on the floor.
+            result["schema"].append({
+                "error": "not_an_object",
+                "raw_snippet": (script.string or "")[:120],
+            })
+            continue
 
-        # @type may be a list; a retired type anywhere in it wins, matching the
-        # single-type precedence this replaced.
-        names = _type_names(schema_type)
-        retired = next((n for n in names if n in DEPRECATED_SCHEMA), None)
-        no_rich = next((n for n in names if n in NO_RICH_RESULTS), None)
-
-        if retired:
-            status = "deprecated"
-            note = f"{retired} is retired — Google no longer processes this type. Remove or replace."
-        elif no_rich:
-            status = "no_rich_results"
-            note = f"{no_rich} no longer produces a Google rich result, but the schema is still valid. Keep it."
-
-        # FAQ answer text in JSON-LD but not in the rendered HTML is
-        # invisible to users and AI crawlers (procedures/03 step 4).
-        missing_faq = faq_parity.missing_answers(schema_data, page_text)
-
-        result["schema"].append({
-            "@type": schema_type,
-            "faq_answers_missing_from_html": missing_faq,
-            "@context": schema_data.get("@context", ""),
-            "status": status,
-            "note": note,
-            "has_context": bool(schema_data.get("@context")),
-            "has_type": bool(schema_data.get("@type")),
-            "raw": schema_data,
-        })
+        for node in nodes:
+            result["schema"].append(_describe_schema_node(node, page_text))
 
     # Word count (visible text only)
     for element in soup(["script", "style", "nav", "footer", "header"]):

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/parse_html.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/parse_html.py
@@ -36,6 +36,21 @@ except ImportError:
     sys.exit(1)
 
 
+def _type_names(value) -> list:
+    """Return the @type value as a list of type strings.
+
+    JSON-LD allows @type to be a single string or a list — a multi-typed node
+    such as ["WebPage", "FAQPage"] is valid and common. Testing the raw value
+    with `value in DEPRECATED_SCHEMA` raised TypeError: unhashable type: 'list'
+    on the list form.
+    """
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [v for v in value if isinstance(v, str)]
+    return []
+
+
 def _link_rel_has_canonical(rel) -> bool:
     if rel is None:
         return False
@@ -239,12 +254,18 @@ def parse_html(html: str, base_url: Optional[str] = None) -> dict:
         status = "active"
         note = ""
 
-        if schema_type in DEPRECATED_SCHEMA:
+        # @type may be a list; a retired type anywhere in it wins, matching the
+        # single-type precedence this replaced.
+        names = _type_names(schema_type)
+        retired = next((n for n in names if n in DEPRECATED_SCHEMA), None)
+        no_rich = next((n for n in names if n in NO_RICH_RESULTS), None)
+
+        if retired:
             status = "deprecated"
-            note = f"{schema_type} is retired — Google no longer processes this type. Remove or replace."
-        elif schema_type in NO_RICH_RESULTS:
+            note = f"{retired} is retired — Google no longer processes this type. Remove or replace."
+        elif no_rich:
             status = "no_rich_results"
-            note = f"{schema_type} no longer produces a Google rich result, but the schema is still valid. Keep it."
+            note = f"{no_rich} no longer produces a Google rich result, but the schema is still valid. Keep it."
 
         # FAQ answer text in JSON-LD but not in the rendered HTML is
         # invisible to users and AI crawlers (procedures/03 step 4).

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/validate_schema.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/validate_schema.py
@@ -16,6 +16,7 @@ import sys
 from typing import List
 
 import faq_parity
+import jsonld
 
 # Module-level so tests/test_schema_status_parity.py can check these against
 # the tables in references/schema-types.md. Docs and code may only drift by
@@ -41,21 +42,6 @@ NO_RICH_RESULTS_TYPES = {
     "Dataset": "Dataset markup is consumed by Dataset Search only, not general Google Search (clarified Nov 5, 2025) — still valid and supported; keep it",
     "Quiz": "Google retired the practice problem rich result (Jan 2026) but schema.org Quiz is still valid — keep for Bing, AI systems, and content understanding",
 }
-
-
-def _type_names(value) -> List[str]:
-    """Return the @type value as a list of type strings.
-
-    JSON-LD allows @type to be a single string or a list — a multi-typed node
-    such as ["WebPage", "FAQPage"] is valid and common. Testing the raw value
-    with `value in RETIRED_TYPES` raised TypeError: unhashable type: 'list' on
-    the list form, aborting validation of the whole page.
-    """
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, list):
-        return [v for v in value if isinstance(v, str)]
-    return []
 
 
 def validate_jsonld(content: str, check_html_parity: bool = False) -> List[str]:
@@ -157,7 +143,7 @@ def _validate_schema_object(
         if p.lower() in text.lower():
             errors.append(f"{prefix}: Contains placeholder text: {p}")
 
-    for schema_type in _type_names(obj.get("@type")):
+    for schema_type in jsonld.type_names(obj.get("@type")):
         if schema_type in RETIRED_TYPES:
             errors.append(
                 f"{prefix}: @type '{schema_type}' is {RETIRED_TYPES[schema_type]}"

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/validate_schema.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/validate_schema.py
@@ -43,6 +43,21 @@ NO_RICH_RESULTS_TYPES = {
 }
 
 
+def _type_names(value) -> List[str]:
+    """Return the @type value as a list of type strings.
+
+    JSON-LD allows @type to be a single string or a list — a multi-typed node
+    such as ["WebPage", "FAQPage"] is valid and common. Testing the raw value
+    with `value in RETIRED_TYPES` raised TypeError: unhashable type: 'list' on
+    the list form, aborting validation of the whole page.
+    """
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [v for v in value if isinstance(v, str)]
+    return []
+
+
 def validate_jsonld(content: str, check_html_parity: bool = False) -> List[str]:
     """Validate JSON-LD blocks in HTML content.
 
@@ -142,13 +157,14 @@ def _validate_schema_object(
         if p.lower() in text.lower():
             errors.append(f"{prefix}: Contains placeholder text: {p}")
 
-    schema_type = obj.get("@type", "")
+    for schema_type in _type_names(obj.get("@type")):
+        if schema_type in RETIRED_TYPES:
+            errors.append(
+                f"{prefix}: @type '{schema_type}' is {RETIRED_TYPES[schema_type]}"
+            )
 
-    if schema_type in RETIRED_TYPES:
-        errors.append(f"{prefix}: @type '{schema_type}' is {RETIRED_TYPES[schema_type]}")
-
-    if schema_type in NO_RICH_RESULTS_TYPES:
-        errors.append(f"[info] {prefix}: {NO_RICH_RESULTS_TYPES[schema_type]}")
+        if schema_type in NO_RICH_RESULTS_TYPES:
+            errors.append(f"[info] {prefix}: {NO_RICH_RESULTS_TYPES[schema_type]}")
 
     return errors
 

--- a/scripts/article_seo.py
+++ b/scripts/article_seo.py
@@ -275,6 +275,57 @@ def extract_content(soup: BeautifulSoup, cms: str) -> dict:
 # JSON-LD structured data extraction
 # ---------------------------------------------------------------------------
 
+def _schema_nodes(data) -> list:
+    """Every schema node carried by one JSON-LD block.
+
+    A block may hold a single object or a top-level array of objects — both are
+    valid JSON-LD and both are emitted by real CMSes. Calling .get() straight on
+    the array form raised AttributeError, killing the parse for the whole page.
+    Each member is reported as its own block so a retired type buried in an
+    array is still flagged.
+    """
+    if isinstance(data, dict):
+        return [data]
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    return []
+
+
+def _describe_schema_node(node: dict, page_text: str) -> dict:
+    """Status, note and FAQ parity for a single JSON-LD node."""
+    schema_type = node.get("@type", "Unknown")
+    status = "active"
+    note = ""
+
+    # @type may be a list; a retired type anywhere in it wins, matching the
+    # single-type precedence this replaced.
+    names = _type_names(schema_type)
+    retired = next((n for n in names if n in DEPRECATED_SCHEMA), None)
+    no_rich = next((n for n in names if n in NO_RICH_RESULTS), None)
+
+    if retired:
+        status = "deprecated"
+        note = f"{retired} is retired — Google no longer processes this type. Remove or replace."
+    elif no_rich:
+        status = "no_rich_results"
+        note = f"{no_rich} no longer produces a Google rich result, but the schema is still valid. Keep it."
+
+    return {
+        "@type": schema_type,
+        # FAQ answer text in JSON-LD but not in the rendered HTML is
+        # invisible to users and AI crawlers (procedures/03 step 4).
+        "faq_answers_missing_from_html": (
+            faq_parity.missing_answers(node, page_text) if page_text else []
+        ),
+        "@context": node.get("@context", ""),
+        "status": status,
+        "note": note,
+        "has_context": bool(node.get("@context")),
+        "has_type": bool(node.get("@type")),
+        "raw": node,
+    }
+
+
 def extract_structured_data(soup: BeautifulSoup, page_text: str = "") -> list:
     """
     Extract and parse all <script type="application/ld+json"> blocks.
@@ -289,37 +340,15 @@ def extract_structured_data(soup: BeautifulSoup, page_text: str = "") -> list:
             blocks.append({"error": "invalid_json", "raw_snippet": raw[:120]})
             continue
 
-        schema_type = data.get("@type", "Unknown")
-        status = "active"
-        note = ""
+        nodes = _schema_nodes(data)
+        if not nodes:
+            # Valid JSON, but nothing object-shaped in it — say so rather than
+            # dropping the block on the floor.
+            blocks.append({"error": "not_an_object", "raw_snippet": raw[:120]})
+            continue
 
-        # @type may be a list; a retired type anywhere in it wins, matching the
-        # single-type precedence this replaced.
-        names = _type_names(schema_type)
-        retired = next((n for n in names if n in DEPRECATED_SCHEMA), None)
-        no_rich = next((n for n in names if n in NO_RICH_RESULTS), None)
-
-        if retired:
-            status = "deprecated"
-            note = f"{retired} is retired — Google no longer processes this type. Remove or replace."
-        elif no_rich:
-            status = "no_rich_results"
-            note = f"{no_rich} no longer produces a Google rich result, but the schema is still valid. Keep it."
-
-        # FAQ answer text in JSON-LD but not in the rendered HTML is
-        # invisible to users and AI crawlers (procedures/03 step 4).
-        missing_faq = faq_parity.missing_answers(data, page_text) if page_text else []
-
-        blocks.append({
-            "@type": schema_type,
-            "faq_answers_missing_from_html": missing_faq,
-            "@context": data.get("@context", ""),
-            "status": status,
-            "note": note,
-            "has_context": bool(data.get("@context")),
-            "has_type": bool(data.get("@type")),
-            "raw": data,
-        })
+        for node in nodes:
+            blocks.append(_describe_schema_node(node, page_text))
 
     return blocks
 

--- a/scripts/article_seo.py
+++ b/scripts/article_seo.py
@@ -75,6 +75,21 @@ NO_RICH_RESULTS = {"HowTo", "FAQPage", "Quiz", "Dataset"}
 # Fetch
 # ---------------------------------------------------------------------------
 
+def _type_names(value) -> list:
+    """Return the @type value as a list of type strings.
+
+    JSON-LD allows @type to be a single string or a list — a multi-typed node
+    such as ["WebPage", "FAQPage"] is valid and common. Testing the raw value
+    with `value in DEPRECATED_SCHEMA` raised TypeError: unhashable type: 'list'
+    on the list form.
+    """
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [v for v in value if isinstance(v, str)]
+    return []
+
+
 def fetch_html(url: str) -> str:
     """Fetch raw HTML from a URL with a realistic browser user-agent."""
     try:
@@ -278,12 +293,18 @@ def extract_structured_data(soup: BeautifulSoup, page_text: str = "") -> list:
         status = "active"
         note = ""
 
-        if schema_type in DEPRECATED_SCHEMA:
+        # @type may be a list; a retired type anywhere in it wins, matching the
+        # single-type precedence this replaced.
+        names = _type_names(schema_type)
+        retired = next((n for n in names if n in DEPRECATED_SCHEMA), None)
+        no_rich = next((n for n in names if n in NO_RICH_RESULTS), None)
+
+        if retired:
             status = "deprecated"
-            note = f"{schema_type} is retired — Google no longer processes this type. Remove or replace."
-        elif schema_type in NO_RICH_RESULTS:
+            note = f"{retired} is retired — Google no longer processes this type. Remove or replace."
+        elif no_rich:
             status = "no_rich_results"
-            note = f"{schema_type} no longer produces a Google rich result, but the schema is still valid. Keep it."
+            note = f"{no_rich} no longer produces a Google rich result, but the schema is still valid. Keep it."
 
         # FAQ answer text in JSON-LD but not in the rendered HTML is
         # invisible to users and AI crawlers (procedures/03 step 4).

--- a/scripts/article_seo.py
+++ b/scripts/article_seo.py
@@ -22,6 +22,7 @@ import argparse
 import json
 
 import faq_parity
+import jsonld
 import re
 import sys
 import math
@@ -74,21 +75,6 @@ NO_RICH_RESULTS = {"HowTo", "FAQPage", "Quiz", "Dataset"}
 # ---------------------------------------------------------------------------
 # Fetch
 # ---------------------------------------------------------------------------
-
-def _type_names(value) -> list:
-    """Return the @type value as a list of type strings.
-
-    JSON-LD allows @type to be a single string or a list — a multi-typed node
-    such as ["WebPage", "FAQPage"] is valid and common. Testing the raw value
-    with `value in DEPRECATED_SCHEMA` raised TypeError: unhashable type: 'list'
-    on the list form.
-    """
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, list):
-        return [v for v in value if isinstance(v, str)]
-    return []
-
 
 def fetch_html(url: str) -> str:
     """Fetch raw HTML from a URL with a realistic browser user-agent."""
@@ -275,22 +261,6 @@ def extract_content(soup: BeautifulSoup, cms: str) -> dict:
 # JSON-LD structured data extraction
 # ---------------------------------------------------------------------------
 
-def _schema_nodes(data) -> list:
-    """Every schema node carried by one JSON-LD block.
-
-    A block may hold a single object or a top-level array of objects — both are
-    valid JSON-LD and both are emitted by real CMSes. Calling .get() straight on
-    the array form raised AttributeError, killing the parse for the whole page.
-    Each member is reported as its own block so a retired type buried in an
-    array is still flagged.
-    """
-    if isinstance(data, dict):
-        return [data]
-    if isinstance(data, list):
-        return [item for item in data if isinstance(item, dict)]
-    return []
-
-
 def _describe_schema_node(node: dict, page_text: str) -> dict:
     """Status, note and FAQ parity for a single JSON-LD node."""
     schema_type = node.get("@type", "Unknown")
@@ -299,7 +269,7 @@ def _describe_schema_node(node: dict, page_text: str) -> dict:
 
     # @type may be a list; a retired type anywhere in it wins, matching the
     # single-type precedence this replaced.
-    names = _type_names(schema_type)
+    names = jsonld.type_names(schema_type)
     retired = next((n for n in names if n in DEPRECATED_SCHEMA), None)
     no_rich = next((n for n in names if n in NO_RICH_RESULTS), None)
 
@@ -340,7 +310,7 @@ def extract_structured_data(soup: BeautifulSoup, page_text: str = "") -> list:
             blocks.append({"error": "invalid_json", "raw_snippet": raw[:120]})
             continue
 
-        nodes = _schema_nodes(data)
+        nodes = jsonld.nodes(data)
         if not nodes:
             # Valid JSON, but nothing object-shaped in it — say so rather than
             # dropping the block on the floor.

--- a/scripts/broken_links.py
+++ b/scripts/broken_links.py
@@ -70,6 +70,17 @@ def extract_links(html: str, base_url: str) -> list:
     return links
 
 
+def is_redirect_chain(link_result: dict) -> bool:
+    """True when a checked link travelled through more than one redirect hop.
+
+    `check_link` initialises "redirect" to None on every result, so the {}
+    default of `.get("redirect", {})` was never reached: the call returned None
+    and chaining `.get("hops", 0)` onto it raised AttributeError on the first
+    link that was not redirected.
+    """
+    return (link_result.get("redirect") or {}).get("hops", 0) > 1
+
+
 def check_link(link: dict, timeout: int = 10, detect_soft_404: bool = True) -> dict:
     """Check a single link's HTTP status, including soft 404 detection."""
     url = link["url"]
@@ -225,8 +236,7 @@ def check_broken_links(url: str, internal_only: bool = False,
             f"⚠️ {len(result['timeout'])} link(s) timed out"
         )
     if result["redirected"]:
-        chains = [l for l in result["redirected"]
-                  if l.get("redirect", {}).get("hops", 0) > 1]
+        chains = [l for l in result["redirected"] if is_redirect_chain(l)]
         if chains:
             result["issues"].append(
                 f"⚠️ {len(chains)} redirect chain(s) detected (>1 hop)"
@@ -312,7 +322,7 @@ def crawl_broken_links(start_url: str, max_depth: int = 2, max_pages: int = 50,
                 elif status and status >= 400:
                     all_broken.append(link_result)
                     broken_by_target[link_result["url"]].append(page_url)
-                elif link_result.get("redirect", {}).get("hops", 0) > 1:
+                elif is_redirect_chain(link_result):
                     all_chains.append(link_result)
                 else:
                     healthy_count += 1
@@ -441,8 +451,7 @@ def main():
 
     redirected = result.get("redirected", result.get("redirected_chains", []))
     if redirected:
-        chains = [l for l in redirected
-                  if l.get("redirect", {}).get("hops", 0) > 1]
+        chains = [l for l in redirected if is_redirect_chain(l)]
         if chains:
             print(f"\n⚠️ Redirect Chains (>1 hop):")
             for link in chains:

--- a/scripts/entity_checker.py
+++ b/scripts/entity_checker.py
@@ -21,6 +21,8 @@ import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from urllib.parse import urlparse
 
+import jsonld
+
 try:
     from bs4 import BeautifulSoup
 except ImportError:
@@ -69,21 +71,6 @@ ENTITY_TYPES = (
 )
 
 
-def _type_names(value) -> list:
-    """Return the @type value as a list of type strings.
-
-    JSON-LD allows @type to be a single string or a list. A multi-typed node
-    such as ["LocalBusiness", "Organization"] is valid and common; comparing
-    the raw value against ENTITY_TYPES matched nothing, so the entity was
-    dropped without error and the page reported no entity signals at all.
-    """
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, list):
-        return [v for v in value if isinstance(v, str)]
-    return []
-
-
 def extract_entities_from_schema(soup: BeautifulSoup) -> list:
     """Extract Organization/Person entities and their sameAs from JSON-LD."""
     entities = []
@@ -110,7 +97,7 @@ def extract_entities_from_schema(soup: BeautifulSoup) -> list:
             # entity["type"] for membership and prints it, so a list here
             # would reintroduce the same silent miss one layer further on.
             entity_type = next(
-                (n for n in _type_names(item.get("@type")) if n in ENTITY_TYPES),
+                (n for n in jsonld.type_names(item.get("@type")) if n in ENTITY_TYPES),
                 None,
             )
             if entity_type:

--- a/scripts/entity_checker.py
+++ b/scripts/entity_checker.py
@@ -63,6 +63,27 @@ def fetch_html(url: str, timeout: int = 12) -> str:
 # Schema extraction
 # ---------------------------------------------------------------------------
 
+ENTITY_TYPES = (
+    "Organization", "Person", "Corporation", "LocalBusiness", "Brand",
+    "MedicalOrganization", "EducationalOrganization", "GovernmentOrganization",
+)
+
+
+def _type_names(value) -> list:
+    """Return the @type value as a list of type strings.
+
+    JSON-LD allows @type to be a single string or a list. A multi-typed node
+    such as ["LocalBusiness", "Organization"] is valid and common; comparing
+    the raw value against ENTITY_TYPES matched nothing, so the entity was
+    dropped without error and the page reported no entity signals at all.
+    """
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [v for v in value if isinstance(v, str)]
+    return []
+
+
 def extract_entities_from_schema(soup: BeautifulSoup) -> list:
     """Extract Organization/Person entities and their sameAs from JSON-LD."""
     entities = []
@@ -85,13 +106,16 @@ def extract_entities_from_schema(soup: BeautifulSoup) -> list:
         for item in items:
             if not isinstance(item, dict):
                 continue
-            schema_type = item.get("@type", "")
-            # Look for entity types
-            if schema_type in ("Organization", "Person", "Corporation",
-                               "LocalBusiness", "Brand", "MedicalOrganization",
-                               "EducationalOrganization", "GovernmentOrganization"):
+            # The matched name, not the raw @type: downstream code tests
+            # entity["type"] for membership and prints it, so a list here
+            # would reintroduce the same silent miss one layer further on.
+            entity_type = next(
+                (n for n in _type_names(item.get("@type")) if n in ENTITY_TYPES),
+                None,
+            )
+            if entity_type:
                 entities.append({
-                    "type": schema_type,
+                    "type": entity_type,
                     "name": item.get("name", ""),
                     "url": item.get("url", ""),
                     "sameAs": item.get("sameAs", []),

--- a/scripts/faq_parity.py
+++ b/scripts/faq_parity.py
@@ -53,11 +53,25 @@ def visible_text(html_content: str) -> str:
     return normalize(_SCRIPT_STYLE_RE.sub(" ", html_content or ""))
 
 
+def _is_type(node, wanted: str) -> bool:
+    """True when a node declares `wanted`, as a string or inside a list @type.
+
+    JSON-LD allows @type to be a list, and `["WebPage", "FAQPage"]` is the
+    ordinary shape for a page that is both. Comparing the raw value with `!=`
+    skipped those nodes, so parity silently passed on exactly the pages that
+    carry FAQ markup alongside a page type.
+    """
+    if not isinstance(node, dict):
+        return False
+    value = node.get("@type")
+    if isinstance(value, list):
+        return wanted in value
+    return value == wanted
+
+
 def _iter_questions(schema_obj):
     """Yield Question nodes from a FAQPage `mainEntity`, list or single."""
-    if not isinstance(schema_obj, dict):
-        return
-    if schema_obj.get("@type") != "FAQPage":
+    if not _is_type(schema_obj, "FAQPage"):
         return
     entity = schema_obj.get("mainEntity")
     if isinstance(entity, dict):
@@ -65,7 +79,7 @@ def _iter_questions(schema_obj):
     if not isinstance(entity, list):
         return
     for node in entity:
-        if isinstance(node, dict) and node.get("@type") == "Question":
+        if _is_type(node, "Question"):
             yield node
 
 

--- a/scripts/faq_parity.py
+++ b/scripts/faq_parity.py
@@ -17,6 +17,8 @@ that the rendered DOM does not, so raw equality reports false misses.
 
 import html
 import re
+
+import jsonld
 from typing import List
 
 # Answers shorter than this are skipped: a handful of characters can appear
@@ -53,25 +55,9 @@ def visible_text(html_content: str) -> str:
     return normalize(_SCRIPT_STYLE_RE.sub(" ", html_content or ""))
 
 
-def _is_type(node, wanted: str) -> bool:
-    """True when a node declares `wanted`, as a string or inside a list @type.
-
-    JSON-LD allows @type to be a list, and `["WebPage", "FAQPage"]` is the
-    ordinary shape for a page that is both. Comparing the raw value with `!=`
-    skipped those nodes, so parity silently passed on exactly the pages that
-    carry FAQ markup alongside a page type.
-    """
-    if not isinstance(node, dict):
-        return False
-    value = node.get("@type")
-    if isinstance(value, list):
-        return wanted in value
-    return value == wanted
-
-
 def _iter_questions(schema_obj):
     """Yield Question nodes from a FAQPage `mainEntity`, list or single."""
-    if not _is_type(schema_obj, "FAQPage"):
+    if not jsonld.is_type(schema_obj, "FAQPage"):
         return
     entity = schema_obj.get("mainEntity")
     if isinstance(entity, dict):
@@ -79,7 +65,7 @@ def _iter_questions(schema_obj):
     if not isinstance(entity, list):
         return
     for node in entity:
-        if _is_type(node, "Question"):
+        if jsonld.is_type(node, "Question"):
             yield node
 
 

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -28,6 +28,8 @@ from typing import Optional
 import re
 import subprocess
 import sys
+
+import jsonld
 import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -208,20 +210,6 @@ def _platform_hint(primary: str, area: str) -> str:
     return platform_map.get(primary, fallback).get(area, fallback.get(area, ""))
 
 
-def _type_names(value) -> list:
-    """Return the @type value as a list of type strings.
-
-    JSON-LD allows @type to be a single string or a list, and parse_html.py
-    passes the value through untouched, so the schema blocks this report reads
-    carry both shapes.
-    """
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, list):
-        return [v for v in value if isinstance(v, str)]
-    return []
-
-
 def build_environment_fixes(data: dict) -> list:
     """Build actionable issue fixes tailored to detected environment."""
     env = data.get("environment", {})
@@ -309,14 +297,14 @@ def build_environment_fixes(data: dict) -> list:
     # Raising it on a site that never appears in Top Stories is noise, so gate the
     # finding on a publisher signal rather than reporting it everywhere.
     ps = data["sections"].get("preferred_sources", {})
-    # Flattened via _type_names: str() on a list @type produced
+    # Flattened via jsonld.type_names: str() on a list @type produced
     # "['NewsArticle', 'Article']", which matches nothing below, so the
     # preferred-sources findings vanished on every multi-typed publisher page.
     schema_types = {
         name
         for s in (op.get("schema") or [])
         if isinstance(s, dict)
-        for name in _type_names(s.get("@type"))
+        for name in jsonld.type_names(s.get("@type"))
     }
     looks_like_publisher = bool(schema_types & {"NewsArticle", "NewsMediaOrganization", "LiveBlogPosting"})
     if ps and not ps.get("error") and looks_like_publisher:

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -208,6 +208,20 @@ def _platform_hint(primary: str, area: str) -> str:
     return platform_map.get(primary, fallback).get(area, fallback.get(area, ""))
 
 
+def _type_names(value) -> list:
+    """Return the @type value as a list of type strings.
+
+    JSON-LD allows @type to be a single string or a list, and parse_html.py
+    passes the value through untouched, so the schema blocks this report reads
+    carry both shapes.
+    """
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [v for v in value if isinstance(v, str)]
+    return []
+
+
 def build_environment_fixes(data: dict) -> list:
     """Build actionable issue fixes tailored to detected environment."""
     env = data.get("environment", {})
@@ -295,8 +309,14 @@ def build_environment_fixes(data: dict) -> list:
     # Raising it on a site that never appears in Top Stories is noise, so gate the
     # finding on a publisher signal rather than reporting it everywhere.
     ps = data["sections"].get("preferred_sources", {})
+    # Flattened via _type_names: str() on a list @type produced
+    # "['NewsArticle', 'Article']", which matches nothing below, so the
+    # preferred-sources findings vanished on every multi-typed publisher page.
     schema_types = {
-        str(s.get("@type", "")) for s in (op.get("schema") or []) if isinstance(s, dict)
+        name
+        for s in (op.get("schema") or [])
+        if isinstance(s, dict)
+        for name in _type_names(s.get("@type"))
     }
     looks_like_publisher = bool(schema_types & {"NewsArticle", "NewsMediaOrganization", "LiveBlogPosting"})
     if ps and not ps.get("error") and looks_like_publisher:

--- a/scripts/internal_links.py
+++ b/scripts/internal_links.py
@@ -33,6 +33,15 @@ except ImportError:
 HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; UltimateSEO/1.8)"}
 
 
+def _dedup_key(url: str) -> str:
+    """Slash-insensitive identity for a URL.
+
+    /gallery and /gallery/ are the same page for counting and de-duplication,
+    but only one of them is what the page actually linked to.
+    """
+    return url.rstrip("/") or url
+
+
 def extract_internal_links(html: str, page_url: str, domain: str) -> list:
     """Extract internal links from HTML."""
     soup = BeautifulSoup(html, "html.parser")
@@ -51,20 +60,25 @@ def extract_internal_links(html: str, page_url: str, domain: str) -> list:
         if parsed.netloc != domain:
             continue
 
-        normalized = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
-        if parsed.path in ("", "/"):
-            normalized = f"{parsed.scheme}://{parsed.netloc}"
-        elif normalized.endswith("/"):
-            normalized = normalized.rstrip("/")
+        # Keep the href's own trailing slash. Stripping it made the crawler
+        # request a URL the page never linked to; a site that canonicalises to
+        # /path/ then 301s straight back, and that round trip — created by this
+        # script's own normalisation, not by the HTML — was reported as
+        # "internal link points to a redirect URL". De-duplication stays
+        # slash-insensitive so /gallery and /gallery/ still count once.
+        target = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+        if parsed.path == "":
+            target = f"{parsed.scheme}://{parsed.netloc}/"
 
-        if normalized in seen:
+        key = _dedup_key(target)
+        if key in seen:
             continue
-        seen.add(normalized)
+        seen.add(key)
 
         anchor_text = tag.get_text(strip=True)[:80] or "[no text]"
         nofollow = "nofollow" in (tag.get("rel", []) or [])
         links.append({
-            "url": normalized,
+            "url": target,
             "anchor_text": anchor_text,
             "nofollow": nofollow,
             "source": page_url,
@@ -119,6 +133,7 @@ def crawl_site(start_url: str, max_depth: int = 2, max_pages: int = 50,
 
     # BFS crawl
     visited = set()
+    visited_keys = set()  # slash-insensitive, so /a and /a/ are not fetched twice
     queue = [(start_url, 0)]  # (url, depth)
     all_links = []
     page_link_counts = {}
@@ -154,8 +169,9 @@ def crawl_site(start_url: str, max_depth: int = 2, max_pages: int = 50,
         batch = []
         while queue and len(batch) < max_workers:
             url, depth = queue.pop(0)
-            if url in visited or depth > max_depth:
+            if _dedup_key(url) in visited_keys or depth > max_depth:
                 continue
+            visited_keys.add(_dedup_key(url))
             visited.add(url)
             batch.append((url, depth))
 
@@ -202,7 +218,7 @@ def crawl_site(start_url: str, max_depth: int = 2, max_pages: int = 50,
                     if link["nofollow"]:
                         result["nofollow_links"].append(link)
 
-                    if link["url"] not in visited and depth + 1 <= max_depth:
+                    if _dedup_key(link["url"]) not in visited_keys and depth + 1 <= max_depth:
                         queue.append((link["url"], depth + 1))
 
     for link in all_links:

--- a/scripts/jsonld.py
+++ b/scripts/jsonld.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Shape-normalising helpers for JSON-LD.
+
+`@type` may be a string or a list, and one `<script type="application/ld+json">`
+block may hold a single object or a top-level array of them. Both shapes are
+valid, both appear on real sites, and every audit script that assumed the single
+form failed on the other — some by raising `TypeError`/`AttributeError`, the
+more dangerous ones by silently reporting nothing and passing the page as clean.
+
+Each script had grown its own copy of the same fix (`_type_names`, `_is_type`,
+`_declares_type`, `_schema_nodes`). This is the one implementation they share,
+so the next shape that needs handling is handled once.
+
+Deliberately dependency-free, stdlib only: `faq_parity.py` and
+`validate_schema.py` are regex/json by design and must not acquire a
+BeautifulSoup dependency through the back door.
+
+Note on scope: this module knows about JSON-LD *shapes* only. Which types are
+retired or no longer produce rich results stays in each script as a
+module-level constant, pinned to `references/schema-types.md` by
+`tests/test_schema_status_parity.py` (decision D-017).
+"""
+
+import re
+from typing import List
+
+
+def type_names(value) -> List[str]:
+    """Return an `@type` value as a list of type strings.
+
+    Accepts the string form, the list form, and anything else (returns empty).
+    Non-string members of a list are dropped rather than coerced — an `@type`
+    of `["Article", {"@id": "..."}]` yields `["Article"]`.
+    """
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [v for v in value if isinstance(v, str)]
+    return []
+
+
+def is_type(node, wanted: str) -> bool:
+    """True when `node` declares `wanted`, as a string or inside a list `@type`.
+
+    `["WebPage", "FAQPage"]` is the ordinary shape for a page that is both, so
+    an `!=` comparison against the raw value skips exactly the pages that carry
+    the markup being looked for.
+    """
+    if not isinstance(node, dict):
+        return False
+    return wanted in type_names(node.get("@type"))
+
+
+def nodes(data) -> list:
+    """Every schema node carried by one parsed JSON-LD block.
+
+    A block may hold a single object or a top-level array of objects. Calling
+    `.get()` straight on the array form raises `AttributeError` and kills the
+    parse for the whole page.
+    """
+    if isinstance(data, dict):
+        return [data]
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    return []
+
+
+def declares_type(html: str, wanted: str) -> bool:
+    """True when raw HTML declares `wanted` as a JSON-LD `@type`, either shape.
+
+    Matches `"@type": "LocalBusiness"` and `"@type": ["LocalBusiness", "Store"]`.
+    For callers that scan raw HTML rather than parsed JSON; prefer `is_type()`
+    where a parsed node is available.
+    """
+    escaped = re.escape(wanted)
+    pattern = r'"@type"\s*:\s*(?:"%s"|\[[^\]]*"%s")' % (escaped, escaped)
+    return bool(re.search(pattern, html or "", re.I))

--- a/scripts/local_signals_checker.py
+++ b/scripts/local_signals_checker.py
@@ -24,6 +24,18 @@ except ImportError:
 USER_AGENT = "Mozilla/5.0 (compatible; UltimateSEO-Local/1.8)"
 
 
+def _declares_type(html: str, wanted: str) -> bool:
+    """True when the raw HTML declares `wanted` as a JSON-LD @type.
+
+    Matches both shapes: `"@type": "LocalBusiness"` and the list form
+    `"@type": ["LocalBusiness", "Store"]`. The string-only pattern this
+    replaced missed multi-typed nodes, so a genuine local business was told —
+    at high severity — to add the schema it already had.
+    """
+    pattern = r'"@type"\s*:\s*(?:"%s"|\[[^\]]*"%s")' % (re.escape(wanted), re.escape(wanted))
+    return bool(re.search(pattern, html, re.I))
+
+
 def check_local_signals(url: str) -> dict:
     parsed = urlparse(url)
     if not parsed.scheme:
@@ -43,9 +55,9 @@ def check_local_signals(url: str) -> dict:
     except Exception as e:
         return {"error": str(e), "url": url}
 
-    lb = bool(re.search(r'"@type"\s*:\s*"LocalBusiness"', html, re.I))
-    org = bool(re.search(r'"@type"\s*:\s*"Organization"', html, re.I))
-    website = bool(re.search(r'"@type"\s*:\s*"WebSite"', html, re.I))
+    lb = _declares_type(html, "LocalBusiness")
+    org = _declares_type(html, "Organization")
+    website = _declares_type(html, "WebSite")
     tel = len(re.findall(r'href=["\']tel:', html, re.I))
     mail = len(re.findall(r'href=["\']mailto:', html, re.I))
     street = bool(

--- a/scripts/local_signals_checker.py
+++ b/scripts/local_signals_checker.py
@@ -15,6 +15,8 @@ import re
 import sys
 from urllib.parse import urlparse
 
+import jsonld
+
 try:
     import requests
 except ImportError:
@@ -22,18 +24,6 @@ except ImportError:
     sys.exit(1)
 
 USER_AGENT = "Mozilla/5.0 (compatible; UltimateSEO-Local/1.8)"
-
-
-def _declares_type(html: str, wanted: str) -> bool:
-    """True when the raw HTML declares `wanted` as a JSON-LD @type.
-
-    Matches both shapes: `"@type": "LocalBusiness"` and the list form
-    `"@type": ["LocalBusiness", "Store"]`. The string-only pattern this
-    replaced missed multi-typed nodes, so a genuine local business was told —
-    at high severity — to add the schema it already had.
-    """
-    pattern = r'"@type"\s*:\s*(?:"%s"|\[[^\]]*"%s")' % (re.escape(wanted), re.escape(wanted))
-    return bool(re.search(pattern, html, re.I))
 
 
 def check_local_signals(url: str) -> dict:
@@ -55,9 +45,9 @@ def check_local_signals(url: str) -> dict:
     except Exception as e:
         return {"error": str(e), "url": url}
 
-    lb = _declares_type(html, "LocalBusiness")
-    org = _declares_type(html, "Organization")
-    website = _declares_type(html, "WebSite")
+    lb = jsonld.declares_type(html, "LocalBusiness")
+    org = jsonld.declares_type(html, "Organization")
+    website = jsonld.declares_type(html, "WebSite")
     tel = len(re.findall(r'href=["\']tel:', html, re.I))
     mail = len(re.findall(r'href=["\']mailto:', html, re.I))
     street = bool(

--- a/scripts/parse_html.py
+++ b/scripts/parse_html.py
@@ -16,6 +16,7 @@ from typing import Optional
 from urllib.parse import urljoin, urlparse
 
 import faq_parity
+import jsonld
 
 # Module-level so tests/test_schema_status_parity.py can check these against
 # the tables in references/schema-types.md.
@@ -36,37 +37,6 @@ except ImportError:
     sys.exit(1)
 
 
-def _type_names(value) -> list:
-    """Return the @type value as a list of type strings.
-
-    JSON-LD allows @type to be a single string or a list — a multi-typed node
-    such as ["WebPage", "FAQPage"] is valid and common. Testing the raw value
-    with `value in DEPRECATED_SCHEMA` raised TypeError: unhashable type: 'list'
-    on the list form.
-    """
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, list):
-        return [v for v in value if isinstance(v, str)]
-    return []
-
-
-def _schema_nodes(data) -> list:
-    """Every schema node carried by one JSON-LD block.
-
-    A block may hold a single object or a top-level array of objects — both are
-    valid JSON-LD and both are emitted by real CMSes. Calling .get() straight on
-    the array form raised AttributeError, killing the parse for the whole page.
-    Each member is reported as its own block so a retired type buried in an
-    array is still flagged.
-    """
-    if isinstance(data, dict):
-        return [data]
-    if isinstance(data, list):
-        return [item for item in data if isinstance(item, dict)]
-    return []
-
-
 def _describe_schema_node(node: dict, page_text: str) -> dict:
     """Status, note and FAQ parity for a single JSON-LD node."""
     schema_type = node.get("@type", "Unknown")
@@ -75,7 +45,7 @@ def _describe_schema_node(node: dict, page_text: str) -> dict:
 
     # @type may be a list; a retired type anywhere in it wins, matching the
     # single-type precedence this replaced.
-    names = _type_names(schema_type)
+    names = jsonld.type_names(schema_type)
     retired = next((n for n in names if n in DEPRECATED_SCHEMA), None)
     no_rich = next((n for n in names if n in NO_RICH_RESULTS), None)
 
@@ -299,7 +269,7 @@ def parse_html(html: str, base_url: Optional[str] = None) -> dict:
             })
             continue
 
-        nodes = _schema_nodes(schema_data)
+        nodes = jsonld.nodes(schema_data)
         if not nodes:
             # Valid JSON, but nothing object-shaped in it — say so rather than
             # dropping the block on the floor.

--- a/scripts/parse_html.py
+++ b/scripts/parse_html.py
@@ -51,6 +51,55 @@ def _type_names(value) -> list:
     return []
 
 
+def _schema_nodes(data) -> list:
+    """Every schema node carried by one JSON-LD block.
+
+    A block may hold a single object or a top-level array of objects — both are
+    valid JSON-LD and both are emitted by real CMSes. Calling .get() straight on
+    the array form raised AttributeError, killing the parse for the whole page.
+    Each member is reported as its own block so a retired type buried in an
+    array is still flagged.
+    """
+    if isinstance(data, dict):
+        return [data]
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    return []
+
+
+def _describe_schema_node(node: dict, page_text: str) -> dict:
+    """Status, note and FAQ parity for a single JSON-LD node."""
+    schema_type = node.get("@type", "Unknown")
+    status = "active"
+    note = ""
+
+    # @type may be a list; a retired type anywhere in it wins, matching the
+    # single-type precedence this replaced.
+    names = _type_names(schema_type)
+    retired = next((n for n in names if n in DEPRECATED_SCHEMA), None)
+    no_rich = next((n for n in names if n in NO_RICH_RESULTS), None)
+
+    if retired:
+        status = "deprecated"
+        note = f"{retired} is retired — Google no longer processes this type. Remove or replace."
+    elif no_rich:
+        status = "no_rich_results"
+        note = f"{no_rich} no longer produces a Google rich result, but the schema is still valid. Keep it."
+
+    return {
+        "@type": schema_type,
+        # FAQ answer text in JSON-LD but not in the rendered HTML is
+        # invisible to users and AI crawlers (procedures/03 step 4).
+        "faq_answers_missing_from_html": faq_parity.missing_answers(node, page_text),
+        "@context": node.get("@context", ""),
+        "status": status,
+        "note": note,
+        "has_context": bool(node.get("@context")),
+        "has_type": bool(node.get("@type")),
+        "raw": node,
+    }
+
+
 def _link_rel_has_canonical(rel) -> bool:
     if rel is None:
         return False
@@ -250,37 +299,18 @@ def parse_html(html: str, base_url: Optional[str] = None) -> dict:
             })
             continue
 
-        schema_type = schema_data.get("@type", "Unknown")
-        status = "active"
-        note = ""
+        nodes = _schema_nodes(schema_data)
+        if not nodes:
+            # Valid JSON, but nothing object-shaped in it — say so rather than
+            # dropping the block on the floor.
+            result["schema"].append({
+                "error": "not_an_object",
+                "raw_snippet": (script.string or "")[:120],
+            })
+            continue
 
-        # @type may be a list; a retired type anywhere in it wins, matching the
-        # single-type precedence this replaced.
-        names = _type_names(schema_type)
-        retired = next((n for n in names if n in DEPRECATED_SCHEMA), None)
-        no_rich = next((n for n in names if n in NO_RICH_RESULTS), None)
-
-        if retired:
-            status = "deprecated"
-            note = f"{retired} is retired — Google no longer processes this type. Remove or replace."
-        elif no_rich:
-            status = "no_rich_results"
-            note = f"{no_rich} no longer produces a Google rich result, but the schema is still valid. Keep it."
-
-        # FAQ answer text in JSON-LD but not in the rendered HTML is
-        # invisible to users and AI crawlers (procedures/03 step 4).
-        missing_faq = faq_parity.missing_answers(schema_data, page_text)
-
-        result["schema"].append({
-            "@type": schema_type,
-            "faq_answers_missing_from_html": missing_faq,
-            "@context": schema_data.get("@context", ""),
-            "status": status,
-            "note": note,
-            "has_context": bool(schema_data.get("@context")),
-            "has_type": bool(schema_data.get("@type")),
-            "raw": schema_data,
-        })
+        for node in nodes:
+            result["schema"].append(_describe_schema_node(node, page_text))
 
     # Word count (visible text only)
     for element in soup(["script", "style", "nav", "footer", "header"]):

--- a/scripts/parse_html.py
+++ b/scripts/parse_html.py
@@ -36,6 +36,21 @@ except ImportError:
     sys.exit(1)
 
 
+def _type_names(value) -> list:
+    """Return the @type value as a list of type strings.
+
+    JSON-LD allows @type to be a single string or a list — a multi-typed node
+    such as ["WebPage", "FAQPage"] is valid and common. Testing the raw value
+    with `value in DEPRECATED_SCHEMA` raised TypeError: unhashable type: 'list'
+    on the list form.
+    """
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [v for v in value if isinstance(v, str)]
+    return []
+
+
 def _link_rel_has_canonical(rel) -> bool:
     if rel is None:
         return False
@@ -239,12 +254,18 @@ def parse_html(html: str, base_url: Optional[str] = None) -> dict:
         status = "active"
         note = ""
 
-        if schema_type in DEPRECATED_SCHEMA:
+        # @type may be a list; a retired type anywhere in it wins, matching the
+        # single-type precedence this replaced.
+        names = _type_names(schema_type)
+        retired = next((n for n in names if n in DEPRECATED_SCHEMA), None)
+        no_rich = next((n for n in names if n in NO_RICH_RESULTS), None)
+
+        if retired:
             status = "deprecated"
-            note = f"{schema_type} is retired — Google no longer processes this type. Remove or replace."
-        elif schema_type in NO_RICH_RESULTS:
+            note = f"{retired} is retired — Google no longer processes this type. Remove or replace."
+        elif no_rich:
             status = "no_rich_results"
-            note = f"{schema_type} no longer produces a Google rich result, but the schema is still valid. Keep it."
+            note = f"{no_rich} no longer produces a Google rich result, but the schema is still valid. Keep it."
 
         # FAQ answer text in JSON-LD but not in the rendered HTML is
         # invisible to users and AI crawlers (procedures/03 step 4).

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -16,6 +16,7 @@ import sys
 from typing import List
 
 import faq_parity
+import jsonld
 
 # Module-level so tests/test_schema_status_parity.py can check these against
 # the tables in references/schema-types.md. Docs and code may only drift by
@@ -41,21 +42,6 @@ NO_RICH_RESULTS_TYPES = {
     "Dataset": "Dataset markup is consumed by Dataset Search only, not general Google Search (clarified Nov 5, 2025) — still valid and supported; keep it",
     "Quiz": "Google retired the practice problem rich result (Jan 2026) but schema.org Quiz is still valid — keep for Bing, AI systems, and content understanding",
 }
-
-
-def _type_names(value) -> List[str]:
-    """Return the @type value as a list of type strings.
-
-    JSON-LD allows @type to be a single string or a list — a multi-typed node
-    such as ["WebPage", "FAQPage"] is valid and common. Testing the raw value
-    with `value in RETIRED_TYPES` raised TypeError: unhashable type: 'list' on
-    the list form, aborting validation of the whole page.
-    """
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, list):
-        return [v for v in value if isinstance(v, str)]
-    return []
 
 
 def validate_jsonld(content: str, check_html_parity: bool = False) -> List[str]:
@@ -157,7 +143,7 @@ def _validate_schema_object(
         if p.lower() in text.lower():
             errors.append(f"{prefix}: Contains placeholder text: {p}")
 
-    for schema_type in _type_names(obj.get("@type")):
+    for schema_type in jsonld.type_names(obj.get("@type")):
         if schema_type in RETIRED_TYPES:
             errors.append(
                 f"{prefix}: @type '{schema_type}' is {RETIRED_TYPES[schema_type]}"

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -43,6 +43,21 @@ NO_RICH_RESULTS_TYPES = {
 }
 
 
+def _type_names(value) -> List[str]:
+    """Return the @type value as a list of type strings.
+
+    JSON-LD allows @type to be a single string or a list — a multi-typed node
+    such as ["WebPage", "FAQPage"] is valid and common. Testing the raw value
+    with `value in RETIRED_TYPES` raised TypeError: unhashable type: 'list' on
+    the list form, aborting validation of the whole page.
+    """
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [v for v in value if isinstance(v, str)]
+    return []
+
+
 def validate_jsonld(content: str, check_html_parity: bool = False) -> List[str]:
     """Validate JSON-LD blocks in HTML content.
 
@@ -142,13 +157,14 @@ def _validate_schema_object(
         if p.lower() in text.lower():
             errors.append(f"{prefix}: Contains placeholder text: {p}")
 
-    schema_type = obj.get("@type", "")
+    for schema_type in _type_names(obj.get("@type")):
+        if schema_type in RETIRED_TYPES:
+            errors.append(
+                f"{prefix}: @type '{schema_type}' is {RETIRED_TYPES[schema_type]}"
+            )
 
-    if schema_type in RETIRED_TYPES:
-        errors.append(f"{prefix}: @type '{schema_type}' is {RETIRED_TYPES[schema_type]}")
-
-    if schema_type in NO_RICH_RESULTS_TYPES:
-        errors.append(f"[info] {prefix}: {NO_RICH_RESULTS_TYPES[schema_type]}")
+        if schema_type in NO_RICH_RESULTS_TYPES:
+            errors.append(f"[info] {prefix}: {NO_RICH_RESULTS_TYPES[schema_type]}")
 
     return errors
 

--- a/tests/test_audit_script_crashes.py
+++ b/tests/test_audit_script_crashes.py
@@ -12,6 +12,10 @@ Each test below fails against the code as it stood before the accompanying fix.
     *array* of nodes. Both called ``.get()`` straight on ``json.loads()`` output and
     raised ``AttributeError`` on the array form; ``validate_schema.py`` already
     branched on it correctly.
+  * ``faq_parity.py`` / ``local_signals_checker.py`` -- the same list ``@type``, in two
+    more consumers that never raised: FAQ parity skipped every multi-typed FAQ page,
+    and a multi-typed LocalBusiness was told at high severity to add the schema it
+    already had.
   * ``internal_links.py`` -- link extraction stripped trailing slashes, the crawler
     then requested a URL the page never linked to, and the site's canonical 301
     back was reported as an internal link pointing to a redirect.
@@ -30,6 +34,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 from bs4 import BeautifulSoup  # noqa: E402
 
 import article_seo  # noqa: E402
+import faq_parity  # noqa: E402
+import local_signals_checker  # noqa: E402
 import entity_checker  # noqa: E402
 import generate_report  # noqa: E402
 import parse_html  # noqa: E402
@@ -290,3 +296,74 @@ def test_publisher_gate_string_type_is_unchanged():
 
 def test_non_publisher_is_still_not_gated_in():
     assert PREFERRED_SOURCES_FIX not in _publisher_fix_titles(["WebPage", "Article"])
+
+
+# --- faq_parity: a page that is both a WebPage and an FAQPage ---------------
+
+FAQ_ANSWER = "Yes, we deliver across the metro area on the same working day."
+
+
+def _faq(type_value, question_type="Question"):
+    return {
+        "@context": "https://schema.org",
+        "@type": type_value,
+        "mainEntity": [{
+            "@type": question_type,
+            "name": "Do you deliver same day?",
+            "acceptedAnswer": {"@type": "Answer", "text": FAQ_ANSWER},
+        }],
+    }
+
+
+def test_multi_typed_faqpage_is_still_checked_for_parity():
+    """["WebPage", "FAQPage"] is the ordinary shape and was skipped entirely."""
+    missing = faq_parity.missing_answers(
+        _faq(["WebPage", "FAQPage"]), faq_parity.visible_text("<p>Nothing here.</p>")
+    )
+    assert missing == ["Do you deliver same day?"]
+
+
+def test_multi_typed_faqpage_with_visible_answer_reports_nothing():
+    missing = faq_parity.missing_answers(
+        _faq(["WebPage", "FAQPage"]),
+        faq_parity.visible_text(f"<p>{FAQ_ANSWER}</p>"),
+    )
+    assert missing == []
+
+
+def test_multi_typed_question_node_is_still_read():
+    missing = faq_parity.missing_answers(
+        _faq("FAQPage", question_type=["Question", "Thing"]),
+        faq_parity.visible_text("<p>Nothing here.</p>"),
+    )
+    assert missing == ["Do you deliver same day?"]
+
+
+def test_non_faq_page_is_still_skipped():
+    assert faq_parity.missing_answers(_faq(["WebPage", "AboutPage"]), "") == []
+
+
+# --- local_signals_checker: a multi-typed LocalBusiness is not missing ------
+
+def test_list_type_localbusiness_is_detected():
+    html = '<script type="application/ld+json">{"@type": ["LocalBusiness", "Store"]}</script>'
+    assert local_signals_checker._declares_type(html, "LocalBusiness") is True
+
+
+def test_string_type_localbusiness_still_detected():
+    html = '<script type="application/ld+json">{"@type": "LocalBusiness"}</script>'
+    assert local_signals_checker._declares_type(html, "LocalBusiness") is True
+
+
+def test_absent_type_is_not_detected():
+    html = '<script type="application/ld+json">{"@type": ["Store", "Organization"]}</script>'
+    assert local_signals_checker._declares_type(html, "LocalBusiness") is False
+
+
+@pytest.mark.parametrize("payload", [
+    '{"@type":["LocalBusiness","Store"]}',
+    '{"@type": [ "Store" , "LocalBusiness" ]}',
+    '{"@type":"LocalBusiness"}',
+])
+def test_spacing_variants_all_detected(payload):
+    assert local_signals_checker._declares_type(payload, "LocalBusiness") is True

--- a/tests/test_audit_script_crashes.py
+++ b/tests/test_audit_script_crashes.py
@@ -1,0 +1,144 @@
+"""Three crashes and one false finding, found by running v1.12.6 on a live site.
+
+Each test below fails against the code as it stood before the accompanying fix.
+
+  * ``broken_links.py``   -- every non-redirected link carries ``"redirect": None``,
+    so ``.get("redirect", {})`` returned None rather than the default and the
+    crawl aborted on the first healthy link.
+  * ``validate_schema.py`` / ``parse_html.py`` / ``article_seo.py`` -- ``@type``
+    may be a list. Testing it against a dict of retired types raised
+    ``TypeError: unhashable type: 'list'``, dropping the whole page from the audit.
+  * ``internal_links.py`` -- link extraction stripped trailing slashes, the crawler
+    then requested a URL the page never linked to, and the site's canonical 301
+    back was reported as an internal link pointing to a redirect.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from bs4 import BeautifulSoup  # noqa: E402
+
+import article_seo  # noqa: E402
+import parse_html  # noqa: E402
+from broken_links import is_redirect_chain  # noqa: E402
+from internal_links import extract_internal_links  # noqa: E402
+import validate_schema  # noqa: E402
+from validate_schema import validate_jsonld  # noqa: E402
+
+
+# --- broken_links: a None redirect is not an empty dict ---------------------
+
+def test_healthy_link_is_not_a_redirect_chain():
+    """check_link() seeds every result with redirect=None."""
+    assert is_redirect_chain({"url": "https://e.com/", "redirect": None}) is False
+
+
+def test_missing_redirect_key_is_not_a_redirect_chain():
+    assert is_redirect_chain({"url": "https://e.com/"}) is False
+
+
+@pytest.mark.parametrize("hops,expected", [(1, False), (2, True), (3, True)])
+def test_redirect_chain_needs_more_than_one_hop(hops, expected):
+    result = {"redirect": {"from": "a", "to": "b", "hops": hops}}
+    assert is_redirect_chain(result) is expected
+
+
+# --- @type may be a list ----------------------------------------------------
+
+def _page(type_value, extra=""):
+    return (
+        '<html><head><script type="application/ld+json">'
+        '{"@context": "https://schema.org", "@type": ' + type_value + extra + "}"
+        "</script></head><body></body></html>"
+    )
+
+
+MULTI = '["WebPage", "FAQPage"]'
+
+
+def test_validate_schema_survives_list_type():
+    errors = validate_jsonld(_page(MULTI))
+    assert not any("Missing @type" in e for e in errors)
+
+
+def test_validate_schema_still_flags_a_retired_type_inside_a_list():
+    errors = validate_jsonld(_page('["WebPage", "ClaimReview"]'))
+    assert any("ClaimReview" in e and "retired" in e for e in errors)
+
+
+def test_validate_schema_reports_no_rich_results_type_inside_a_list():
+    """The note text carries the finding; it does not repeat the type name."""
+    errors = validate_jsonld(_page(MULTI))
+    note = validate_schema.NO_RICH_RESULTS_TYPES["FAQPage"]
+    assert any(e.startswith("[info]") and note in e for e in errors)
+
+
+def test_parse_html_survives_list_type():
+    blocks = parse_html.parse_html(_page('["WebPage", "ClaimReview"]'))["schema"]
+    assert blocks[0]["@type"] == ["WebPage", "ClaimReview"]
+    assert blocks[0]["status"] == "deprecated"
+    assert "ClaimReview" in blocks[0]["note"]
+
+
+def test_parse_html_list_type_precedence_matches_single_type():
+    """A retired type anywhere in the list outranks a no-rich-results one."""
+    blocks = parse_html.parse_html(_page('["FAQPage", "ClaimReview"]'))["schema"]
+    assert blocks[0]["status"] == "deprecated"
+
+
+def test_parse_html_plain_list_type_stays_active():
+    blocks = parse_html.parse_html(_page('["WebPage", "Article"]'))["schema"]
+    assert blocks[0]["status"] == "active"
+
+
+def test_article_seo_survives_list_type():
+    soup = BeautifulSoup(_page(MULTI), "html.parser")
+    blocks = article_seo.extract_structured_data(soup)
+    assert blocks[0]["status"] == "no_rich_results"
+    assert "FAQPage" in blocks[0]["note"]
+
+
+# --- internal_links: don't invent the redirect you then report --------------
+
+DOMAIN = "example.com"
+PAGE = "https://example.com/"
+
+
+def _links(*hrefs):
+    html = "<html><body>" + "".join(
+        f'<a href="{h}">link</a>' for h in hrefs
+    ) + "</body></html>"
+    return extract_internal_links(html, PAGE, DOMAIN)
+
+
+def test_trailing_slash_is_preserved():
+    """The URL reported is the one the page actually linked to."""
+    assert [l["url"] for l in _links("/gallery/")] == ["https://example.com/gallery/"]
+
+
+def test_slashless_href_stays_slashless():
+    assert [l["url"] for l in _links("/gallery")] == ["https://example.com/gallery"]
+
+
+def test_slash_variants_still_deduplicate():
+    assert len(_links("/gallery/", "/gallery")) == 1
+
+
+def test_localised_path_keeps_its_slash():
+    assert [l["url"] for l in _links("/es/galeria/")] == [
+        "https://example.com/es/galeria/"
+    ]
+
+
+def test_root_href_is_requestable():
+    assert [l["url"] for l in _links("https://example.com")] == ["https://example.com/"]
+
+
+def test_query_and_fragment_are_still_dropped():
+    assert [l["url"] for l in _links("/about/?utm_source=x#top")] == [
+        "https://example.com/about/"
+    ]

--- a/tests/test_audit_script_crashes.py
+++ b/tests/test_audit_script_crashes.py
@@ -15,6 +15,9 @@ Each test below fails against the code as it stood before the accompanying fix.
   * ``internal_links.py`` -- link extraction stripped trailing slashes, the crawler
     then requested a URL the page never linked to, and the site's canonical 301
     back was reported as an internal link pointing to a redirect.
+  * ``entity_checker.py`` / ``generate_report.py`` -- the same list ``@type``, one
+    layer out. Neither crashed: they compared the raw value against a tuple or
+    stringified it, matched nothing, and returned a quietly empty result.
 """
 
 import os
@@ -27,6 +30,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 from bs4 import BeautifulSoup  # noqa: E402
 
 import article_seo  # noqa: E402
+import entity_checker  # noqa: E402
+import generate_report  # noqa: E402
 import parse_html  # noqa: E402
 from broken_links import is_redirect_chain  # noqa: E402
 from internal_links import extract_internal_links  # noqa: E402
@@ -210,3 +215,78 @@ def test_invalid_json_still_reports_invalid_json():
         "</script></head><body></body></html>"
     )
     assert parse_html.parse_html(html)["schema"][0]["error"] == "invalid_json"
+
+
+# --- a list @type must not silently empty out its consumers ------------------
+
+def _entities(type_value):
+    html = (
+        '<html><head><script type="application/ld+json">'
+        '{"@context": "https://schema.org", "@type": ' + type_value + ','
+        ' "name": "Acme", "sameAs": ["https://x.com/acme"]}'
+        "</script></head><body></body></html>"
+    )
+    return entity_checker.extract_entities_from_schema(
+        BeautifulSoup(html, "html.parser")
+    )
+
+
+def test_entity_survives_list_type():
+    """A multi-typed Organization is an entity, not a non-entity."""
+    entities = _entities('["LocalBusiness", "Organization"]')
+    assert [e["name"] for e in entities] == ["Acme"]
+
+
+def test_entity_type_is_the_matched_name_not_the_list():
+    """check_nap_consistency() does `e["type"] in (...)` and prints it."""
+    entity = _entities('["LocalBusiness", "Organization"]')[0]
+    assert entity["type"] == "LocalBusiness"
+
+
+def test_entity_string_type_is_unchanged():
+    assert [e["type"] for e in _entities('"Organization"')] == ["Organization"]
+
+
+def test_non_entity_list_type_is_still_ignored():
+    assert _entities('["WebPage", "BreadcrumbList"]') == []
+
+
+def test_entity_survives_a_top_level_array():
+    html = (
+        '<html><head><script type="application/ld+json">'
+        '[{"@type": "WebPage"}, {"@type": ["NewsMediaOrganization", "Organization"],'
+        ' "name": "Acme"}]'
+        "</script></head><body></body></html>"
+    )
+    entities = entity_checker.extract_entities_from_schema(
+        BeautifulSoup(html, "html.parser")
+    )
+    assert [e["type"] for e in entities] == ["Organization"]
+
+
+def _publisher_fix_titles(type_value):
+    """Titles of the fixes build_environment_fixes() raises for a publisher."""
+    data = {
+        "environment": {},
+        "sections": {
+            "onpage": {"schema": [{"@type": type_value}]},
+            "preferred_sources": {"implemented": False, "integration": {}},
+        },
+    }
+    return [f["title"] for f in generate_report.build_environment_fixes(data)]
+
+
+PREFERRED_SOURCES_FIX = "No preferred sources opt-in found"
+
+
+def test_publisher_gate_survives_list_type():
+    """str() on the list matched nothing, so the finding never fired."""
+    assert PREFERRED_SOURCES_FIX in _publisher_fix_titles(["NewsArticle", "Article"])
+
+
+def test_publisher_gate_string_type_is_unchanged():
+    assert PREFERRED_SOURCES_FIX in _publisher_fix_titles("NewsArticle")
+
+
+def test_non_publisher_is_still_not_gated_in():
+    assert PREFERRED_SOURCES_FIX not in _publisher_fix_titles(["WebPage", "Article"])

--- a/tests/test_audit_script_crashes.py
+++ b/tests/test_audit_script_crashes.py
@@ -24,6 +24,7 @@ Each test below fails against the code as it stood before the accompanying fix.
     stringified it, matched nothing, and returned a quietly empty result.
 """
 
+import importlib
 import os
 import sys
 
@@ -34,7 +35,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 from bs4 import BeautifulSoup  # noqa: E402
 
 import article_seo  # noqa: E402
+import entity_checker  # noqa: E402
+import generate_report  # noqa: E402
 import faq_parity  # noqa: E402
+import jsonld  # noqa: E402
 import local_signals_checker  # noqa: E402
 import entity_checker  # noqa: E402
 import generate_report  # noqa: E402
@@ -343,21 +347,23 @@ def test_non_faq_page_is_still_skipped():
     assert faq_parity.missing_answers(_faq(["WebPage", "AboutPage"]), "") == []
 
 
-# --- local_signals_checker: a multi-typed LocalBusiness is not missing ------
+# --- raw-HTML type detection: a multi-typed LocalBusiness is not missing ----
+# local_signals_checker.py scans raw HTML rather than parsed JSON-LD; the
+# detection itself now lives in jsonld.declares_type().
 
 def test_list_type_localbusiness_is_detected():
     html = '<script type="application/ld+json">{"@type": ["LocalBusiness", "Store"]}</script>'
-    assert local_signals_checker._declares_type(html, "LocalBusiness") is True
+    assert jsonld.declares_type(html, "LocalBusiness") is True
 
 
 def test_string_type_localbusiness_still_detected():
     html = '<script type="application/ld+json">{"@type": "LocalBusiness"}</script>'
-    assert local_signals_checker._declares_type(html, "LocalBusiness") is True
+    assert jsonld.declares_type(html, "LocalBusiness") is True
 
 
 def test_absent_type_is_not_detected():
     html = '<script type="application/ld+json">{"@type": ["Store", "Organization"]}</script>'
-    assert local_signals_checker._declares_type(html, "LocalBusiness") is False
+    assert jsonld.declares_type(html, "LocalBusiness") is False
 
 
 @pytest.mark.parametrize("payload", [
@@ -366,4 +372,30 @@ def test_absent_type_is_not_detected():
     '{"@type":"LocalBusiness"}',
 ])
 def test_spacing_variants_all_detected(payload):
-    assert local_signals_checker._declares_type(payload, "LocalBusiness") is True
+    assert jsonld.declares_type(payload, "LocalBusiness") is True
+
+
+# --- one implementation, not seven -----------------------------------------
+
+CONSUMERS = (
+    "validate_schema", "parse_html", "article_seo", "entity_checker",
+    "generate_report", "faq_parity", "local_signals_checker",
+)
+
+
+@pytest.mark.parametrize("name", CONSUMERS)
+def test_every_consumer_shares_the_one_jsonld_implementation(name):
+    """Each script had its own copy of these helpers; they now delegate.
+
+    Also guards importability: a script that lost its `import jsonld` in a
+    later edit fails here rather than at the first live run.
+    """
+    module = importlib.import_module(name)
+    assert module.jsonld is jsonld
+
+
+@pytest.mark.parametrize("name", CONSUMERS)
+def test_no_private_helper_copies_remain(name):
+    module = importlib.import_module(name)
+    for stale in ("_type_names", "_schema_nodes", "_is_type", "_declares_type"):
+        assert not hasattr(module, stale), f"{name}.{stale} is a re-grown copy"

--- a/tests/test_audit_script_crashes.py
+++ b/tests/test_audit_script_crashes.py
@@ -8,6 +8,10 @@ Each test below fails against the code as it stood before the accompanying fix.
   * ``validate_schema.py`` / ``parse_html.py`` / ``article_seo.py`` -- ``@type``
     may be a list. Testing it against a dict of retired types raised
     ``TypeError: unhashable type: 'list'``, dropping the whole page from the audit.
+  * ``parse_html.py`` / ``article_seo.py`` -- a JSON-LD block may hold a top-level
+    *array* of nodes. Both called ``.get()`` straight on ``json.loads()`` output and
+    raised ``AttributeError`` on the array form; ``validate_schema.py`` already
+    branched on it correctly.
   * ``internal_links.py`` -- link extraction stripped trailing slashes, the crawler
     then requested a URL the page never linked to, and the site's canonical 301
     back was reported as an internal link pointing to a redirect.
@@ -142,3 +146,67 @@ def test_query_and_fragment_are_still_dropped():
     assert [l["url"] for l in _links("/about/?utm_source=x#top")] == [
         "https://example.com/about/"
     ]
+
+
+# --- a JSON-LD block may be a top-level array -------------------------------
+
+ARRAY = (
+    '<html><head><script type="application/ld+json">'
+    '[{"@context": "https://schema.org", "@type": "Article", "headline": "x"},'
+    ' {"@context": "https://schema.org", "@type": "BreadcrumbList"}]'
+    "</script></head><body></body></html>"
+)
+
+
+def test_parse_html_survives_a_top_level_array():
+    blocks = parse_html.parse_html(ARRAY)["schema"]
+    assert [b["@type"] for b in blocks] == ["Article", "BreadcrumbList"]
+    assert all(b["status"] == "active" for b in blocks)
+
+
+def test_article_seo_survives_a_top_level_array():
+    blocks = article_seo.extract_structured_data(BeautifulSoup(ARRAY, "html.parser"))
+    assert [b["@type"] for b in blocks] == ["Article", "BreadcrumbList"]
+
+
+def test_retired_type_buried_in_an_array_is_still_flagged():
+    html = (
+        '<html><head><script type="application/ld+json">'
+        '[{"@type": "Article"}, {"@type": "ClaimReview"}]'
+        "</script></head><body></body></html>"
+    )
+    blocks = parse_html.parse_html(html)["schema"]
+    assert [b["status"] for b in blocks] == ["active", "deprecated"]
+
+
+def test_validate_schema_still_validates_every_array_member():
+    html = (
+        '<html><head><script type="application/ld+json">'
+        '[{"@context": "https://schema.org", "@type": "Article"}, {"@type": "Thing"}]'
+        "</script></head><body></body></html>"
+    )
+    errors = validate_jsonld(html)
+    assert any("Missing @context" in e for e in errors)
+
+
+@pytest.mark.parametrize("payload", ["[]", '"just a string"', "[1, 2, 3]", "null"])
+def test_object_free_block_is_reported_not_dropped(payload):
+    """Valid JSON carrying no nodes is surfaced, not silently swallowed."""
+    html = (
+        '<html><head><script type="application/ld+json">'
+        + payload
+        + "</script></head><body></body></html>"
+    )
+    blocks = parse_html.parse_html(html)["schema"]
+    assert [b["error"] for b in blocks] == ["not_an_object"]
+
+    seo_blocks = article_seo.extract_structured_data(BeautifulSoup(html, "html.parser"))
+    assert [b["error"] for b in seo_blocks] == ["not_an_object"]
+
+
+def test_invalid_json_still_reports_invalid_json():
+    html = (
+        '<html><head><script type="application/ld+json">{not json'
+        "</script></head><body></body></html>"
+    )
+    assert parse_html.parse_html(html)["schema"][0]["error"] == "invalid_json"


### PR DESCRIPTION
Three crashes, four silent misses and one false Critical. Three surfaced by running v1.12.6 against a live site; the other five were found by probing the sibling scripts with the same page shapes afterwards.

All eight survived a green 241-test suite because every one needs *real page shapes* to fire — the existing fixtures are all well-formed single-type schema, single-object blocks and slash-free hrefs. **The four that never raised are the more dangerous half:** a crash gets noticed, a page silently reported as clean does not.

## Crashes

### `broken_links.py` — crawl aborted on the first healthy link

`check_link()` seeds every result with `"redirect": None`, so `.get("redirect", {})` returned `None`, not the `{}` default, and chaining `.get("hops", 0)` raised `AttributeError`. The default only applies when the key is *absent*, and it never is. Extracted as `is_redirect_chain()` and used at all three call sites.

### `@type` as a list — `TypeError: unhashable type: 'list'`

Same line, copied three ways, in `validate_schema.py`, `parse_html.py` and `article_seo.py`. JSON-LD allows `"@type": ["WebPage", "FAQPage"]`; testing that list against the retired-types dict dropped the **whole page** from the audit — on the site that surfaced it, `/gallery/` and `/es/galeria/` were reported as clean rather than as failed.

A `_type_names()` helper in each script normalises string-or-list; a retired type anywhere in the list still outranks a no-rich-results one. The status sets stay module-level and CI-pinned per **D-017**.

### Top-level JSON-LD array — the same `AttributeError`, one shape out

`parse_html.py` and `article_seo.py` called `.get()` straight on `json.loads()` output, so a `<script>` block holding `[{...}, {...}]` took the page's parse down. `validate_schema.py` already branched on `isinstance(data, list)` and was the model.

`_schema_nodes()` normalises object-or-array and each member becomes its own block, so a retired type buried in an array is flagged instead of lost. The per-node body moved into `_describe_schema_node()` so the two scripts stop diverging line by line. Valid JSON carrying no objects (`[]`, a bare string) is reported as `not_an_object` rather than dropped in silence. Consequence: `Schema Blocks: N` counts schema *nodes*, not `<script>` tags, on array-form pages.

## Silent misses — the same list `@type`, in consumers that never raised

### `entity_checker.py` — a multi-typed business had *no* entity signals

It compared the raw `@type` against its entity-type tuple, so `{"@type": ["LocalBusiness", "Organization"]}` matched nothing and the page was reported as carrying no entity signals at all. No exception, no finding — a clean bill of health for a page never examined.

Now normalised through `_type_names()`, storing the **matched name** rather than the list: `check_nap_consistency()` tests `entity["type"]` for membership and prints it, so a list there would move the same silent miss one layer on.

### `generate_report.py` — preferred-sources findings vanished on publisher pages

The publisher gate used `str(s.get("@type", ""))`, which turns a multi-typed node into the literal `"['NewsArticle', 'Article']"` and intersects with nothing.

### `faq_parity.py` — one gate disabled the FAQ check in three scripts at once

It gated on `get("@type") != "FAQPage"`, so visible-HTML parity skipped exactly the pages that carry FAQ markup alongside a page type — the ordinary `["WebPage", "FAQPage"]` shape. `validate_schema.py`, `parse_html.py` and `article_seo.py` all route their FAQ check through it. `_is_type()` now accepts either shape, for the `Question` nodes as well as the page.

### `local_signals_checker.py` — telling a local business to add schema it already had

It matched `"@type"\s*:\s*"LocalBusiness"` by regex over the raw HTML, which never sees the list form. A genuine local business carrying `["LocalBusiness", "Store"]` got a **high severity** finding instructing it to add the schema already on the page — the worst failure mode of the four, since it is a confident instruction to do the wrong thing. `_declares_type()` matches both shapes, for `Organization` and `WebSite` too.

`maps_checker.py`, `ecommerce_schema.py` and `content_brief.py` were probed the same way and already handle both shapes.

## False finding

### `internal_links.py` — 94 links-to-redirects that were not in the HTML

Link extraction stripped trailing slashes, the crawler then requested a URL the page never linked to, and the site's canonical 301 back to `/path/` was recorded as an internal link pointing to a redirect. Surfaced as **Critical**, with zero such hrefs in the source.

URLs now keep the href's own slash; de-duplication moved to a slash-insensitive `_dedup_key()`, so `/gallery` and `/gallery/` still count once and are fetched once. A link that genuinely points at a redirect is still flagged.

## Verification

`tests/test_audit_script_crashes.py` — 59 tests covering all eight, each validated by reintroducing the defect and confirming the suite catches it.

End to end, not just unit tests:
- `parse_html.py`, `validate_schema.py` and `article_seo.py` against a fixture carrying a top-level array, a multi-typed `@type` and a retired type — array flattened per node, `ClaimReview` blocked with exit 2, FAQPage reported `[info]`
- `validate_schema.py` against a multi-typed `FAQPage` whose answer is absent from the HTML — now raises the parity finding it used to skip
- `broken_links.py --crawl` against a live site — completes and reports a genuine 2-hop redirect chain where it previously raised on the first link

- `pytest tests/` — **300 passed**, up from a 241 baseline
- CLIs re-run against the same fixtures after the refactor — byte-identical output, from both the repo tree and the plugin bundle
- `scripts/check-plugin-sync.py` — OK, both trees aligned at 1.12.6

CHANGELOG entry under `[Unreleased]`; no version bump — that belongs to the release PR.

## One implementation, not seven

Each script had grown its own `_type_names()` / `_is_type()` / `_schema_nodes()` / `_declares_type()` — the same helper written seven times, which is exactly how the original single-shape assumption came to be fixed in three scripts and missed in four.

New `scripts/jsonld.py` holds `type_names()`, `is_type()`, `nodes()` and `declares_type()`; all seven consumers delegate to it. Stdlib only — `faq_parity.py` and `validate_schema.py` are regex/json by design and must not acquire a BeautifulSoup dependency through a shared module.

**Deliberately not moved:** the retired and no-rich-results sets stay module-level in `validate_schema.py`, `parse_html.py` and `article_seo.py`, pinned to `references/schema-types.md` by `tests/test_schema_status_parity.py` (**D-017**). `jsonld.py` knows about JSON-LD *shapes*; it knows nothing about which types Google retired.

Two parametrised tests pin it per consumer: each module delegates to the shared `jsonld` (which also catches a script that loses its import in a later edit), and no private copy has re-grown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
