### PR TITLE
chore: release 1.12.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
     "name": "Myk Pono"
   },
   "metadata": {
-    "version": "1.12.6"
+    "version": "1.12.7"
   },
   "plugins": [
     {
       "name": "ultimate-seo-geo",
       "description": "Scored SEO audits for developers/marketers using AI agents: technical health, JSON-LD, E-E-A-T, backlinks, GEO (AI Overviews, ChatGPT, Perplexity). 46 scripts; HTML/Excel/PDF. E-commerce schema, drift monitoring, topic clustering, Google API tiers, maps intelligence. Optional MCP (Firecrawl, DataForSEO). Parallel workers: agents/PARALLEL-AUDIT.md. Modes: Audit → Plan → Execute.",
-      "version": "1.12.6",
+      "version": "1.12.7",
       "author": {
         "name": "Myk Pono",
         "url": "https://lab.mykpono.com"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.6 |
+| **Version** | 1.12.7 |
 | **Updated** | 2026-08-22 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [1.12.7] - 2026-08-24
+
+Eight defects in the audit scripts, found by running v1.12.6 against a live site and then probing
+the sibling scripts with the same page shapes. One assumption caused all of them: that a page hands
+you the *simple* form of every JSON-LD shape — a string `@type`, one object per `<script>` block, an
+href without a trailing slash. Three scripts raised on the other form. Four returned nothing and
+reported the page as clean, which is the failure mode that survives a test suite and a reviewer
+both.
+
+The helper that fixes it now exists once, in `scripts/jsonld.py`, rather than seven times — the
+duplication is what let the same one-line fix land in three scripts and skip four.
+
 ### Fixed
 
 - **Three crashes, four silent misses and one false Critical, across nine scripts.** Three

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![AGENTS.md](https://img.shields.io/badge/AGENTS.md-compatible-blue)](https://agents.md)
-[![Version](https://img.shields.io/badge/version-1.12.6-green.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.12.7-green.svg)](CHANGELOG.md)
 [![LLM-Agnostic](https://img.shields.io/badge/LLM--Agnostic-7%2B%20platforms-purple.svg)](#platform-compatibility)
 
 The definitive SEO and Generative Engine Optimization agent for AI coding tools. LLM-agnostic — works on any platform that reads `AGENTS.md`. Runs full site audits with scored findings, generates ready-to-deploy fixes, and optimizes content for both Google Search and AI search engines (Google AI Overviews, AI Mode, ChatGPT Search, Perplexity). Exports HTML, Excel, and PDF reports.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ultimate-seo-geo
 description: Audits and optimizes websites for search engine visibility (SEO) and AI search citation (GEO), covering technical health, E-E-A-T content scoring, domain authority, structured data, rich results, and entity signals. Use when running SEO audits, diagnosing traffic drops or ranking losses, generating Schema.org JSON-LD, checking Core Web Vitals, crawlability, robots.txt, sitemaps, hreflang, backlinks, planning content strategy or site migrations, fixing indexing issues, or optimizing for AI Overviews, ChatGPT, and Perplexity. NOT for paid ads (PPC/SEM), social media strategy, email marketing, or general web development unrelated to search.
-version: 1.12.6
+version: 1.12.7
 ---
 
 # Ultimate SEO + GEO — LLM-Agnostic SEO Agent
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.6 |
+| **Version** | 1.12.7 |
 | **Updated** | 2026-08-12 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/plugins/ultimate-seo-geo/.claude-plugin/plugin.json
+++ b/plugins/ultimate-seo-geo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ultimate-seo-geo",
   "description": "Scored SEO audits for developers and marketers using AI agents: technical health, Schema.org JSON-LD, E-E-A-T, backlinks, domain signals, GEO (AI Overviews, ChatGPT, Perplexity). 46 bundled scripts; HTML/Excel/PDF reports. E-commerce schema, drift monitoring, topic clustering, Google API tiers (GSC/GA4), maps intelligence. Optional MCP (Firecrawl, DataForSEO): references/optional-extensions-mcp.md. Modes: Audit → Plan → Execute.",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "author": {
     "name": "Myk Pono",
     "url": "https://lab.mykpono.com"

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
@@ -2,7 +2,7 @@
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.6 |
+| **Version** | 1.12.7 |
 | **Updated** | 2026-08-22 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/SKILL.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ultimate-seo-geo
 description: Audits and optimizes websites for search engine visibility (SEO) and AI search citation (GEO), covering technical health, E-E-A-T content scoring, domain authority, structured data, rich results, and entity signals. Use when running SEO audits, diagnosing traffic drops or ranking losses, generating Schema.org JSON-LD, checking Core Web Vitals, crawlability, robots.txt, sitemaps, hreflang, backlinks, planning content strategy or site migrations, fixing indexing issues, or optimizing for AI Overviews, ChatGPT, and Perplexity. NOT for paid ads (PPC/SEM), social media strategy, email marketing, or general web development unrelated to search.
-version: 1.12.6
+version: 1.12.7
 ---
 
 # Ultimate SEO + GEO — LLM-Agnostic SEO Agent
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.6 |
+| **Version** | 1.12.7 |
 | **Updated** | 2026-08-12 |
 | **License** | MIT |
 | **Author** | Myk Pono |


### PR DESCRIPTION
Folds `[Unreleased]` into a `## [1.12.7] - 2026-08-24` section and bumps 1.12.6 → 1.12.7. No code changes — everything being released is already on `main` via #44.

## What's in it

Eight defects in the audit scripts, found by running v1.12.6 against a live site and then probing the sibling scripts with the same page shapes. One assumption caused all of them: that a page hands you the *simple* form of every JSON-LD shape — a string `@type`, one object per `<script>` block, an href without a trailing slash.

Three scripts raised on the other form. **Four returned nothing and reported the page as clean** — the failure mode that survives both a test suite and a reviewer:

| script | what it did instead of working |
|---|---|
| `entity_checker.py` | a multi-typed `LocalBusiness` had *no* entity signals |
| `generate_report.py` | preferred-sources findings skipped on every multi-typed publisher |
| `faq_parity.py` | one gate disabled the FAQ check in three scripts at once |
| `local_signals_checker.py` | told a local business, at **high severity**, to add the schema already on its page |

Plus three crashes (`broken_links.py` on the first healthy link, list `@type`, top-level JSON-LD array), `internal_links.py` reporting 94 links-to-redirects that were not in the HTML, and the `scripts/jsonld.py` consolidation that leaves one implementation of the shape helpers instead of seven.

## Release-prep checks

- `[Unreleased]` needed no repair — one Fixed, one Changed, no stranded or duplicated headings. Rebuilt anyway per the routine: **16 bullets in, 16 out**, verified no duplicate headings and nothing stranded above the new section.
- Version bumped in **10 places across 7 files** — `SKILL.md` (×2), `AGENTS.md`, `README.md` badge, `marketplace.json` (×2), `plugin.json`, and both plugin-bundle mirrors. No `1.12.6` remains anywhere outside `CHANGELOG.md`.
- `check_version_sync.py` — all 7 tracked references at 1.12.7
- `check-plugin-sync.py` — both trees aligned at 1.12.7
- `pytest tests/` — 300 passed

## After merging

The tag must point at the **merge commit that carries the bump**, not at your local `main` before pulling — that is exactly how v1.12.2 and v1.12.3 ended up tagging trees that self-reported the previous version. `check_tag_matches_version.py` exists to catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)