### PR TITLE
fix: a LocalBusiness subtype is a LocalBusiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,29 @@
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **A LocalBusiness subtype now counts as a LocalBusiness.** `local_signals_checker.py` matched the
+  literal string `LocalBusiness` and nothing else, so a restaurant, dentist, plumber or bookshop
+  carrying correct, *more specific* schema — the markup schema.org actually asks for — was told at
+  **high** severity to add the schema it already had. `maps_checker.py` had known the subtype list
+  since it was written; the two scripts simply disagreed about what a local business is.
+
+  The taxonomy now lives once in `scripts/jsonld.py` as `LOCAL_BUSINESS_TYPES` (149 types, grouped
+  by parent so it stays checkable against schema.org) and both scripts read it. Coverage is a strict
+  superset of what `maps_checker.py` matched before: the five names in its private set that schema.org
+  has never defined (`Cafe`, `Gym`, `AutoBody`, `BarOrSalon`, and a `selfstorge` typo) are kept as
+  `LOCAL_BUSINESS_ALIASES` so nothing stops being detected — but a page using one now gets a medium
+  finding naming the real type instead of silent acceptance.
+
+### Added
+
+- `jsonld.declared_types()`, `jsonld.local_business_types_in()` and `jsonld.is_local_business()`.
+- `local_signals_checker.py` output gains `localbusiness_types`, and its recommendation names the
+  subtype it found rather than saying "LocalBusiness" back at a page that says "Restaurant".
+- `tests/test_local_business_subtypes.py` (78 tests; suite 300 -> 378), including a parametrised
+  guard that every type
+  `maps_checker.py` matched before this change is still matched.
 
 ## [1.12.7] - 2026-08-24
 

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/jsonld.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/jsonld.py
@@ -15,9 +15,12 @@ Deliberately dependency-free, stdlib only: `faq_parity.py` and
 `validate_schema.py` are regex/json by design and must not acquire a
 BeautifulSoup dependency through the back door.
 
-Note on scope: this module knows about JSON-LD *shapes* only. Which types are
-retired or no longer produce rich results stays in each script as a
-module-level constant, pinned to `references/schema-types.md` by
+Note on scope: this module knows about JSON-LD *shapes*, plus the one piece of
+schema.org taxonomy two scripts both need — the LocalBusiness subtype tree,
+which is a fixed fact about the vocabulary rather than a judgement about it.
+Which types are retired or no longer produce rich results is a judgement, moves
+with Google's announcements, and stays in each script as a module-level
+constant, pinned to `references/schema-types.md` by
 `tests/test_schema_status_parity.py` (decision D-017).
 """
 
@@ -75,3 +78,145 @@ def declares_type(html: str, wanted: str) -> bool:
     escaped = re.escape(wanted)
     pattern = r'"@type"\s*:\s*(?:"%s"|\[[^\]]*"%s")' % (escaped, escaped)
     return bool(re.search(pattern, html or "", re.I))
+
+
+# --- schema.org LocalBusiness hierarchy -------------------------------------
+#
+# A page marked up as `Restaurant` or `Dentist` *is* marked up as a
+# LocalBusiness; schema.org's own guidance is to use the most specific subtype
+# available. Matching the literal string "LocalBusiness" and nothing else told
+# every correctly-marked-up local business, at high severity, to add the schema
+# it already had.
+#
+# Grouped by parent to stay checkable against https://schema.org/LocalBusiness.
+# Lowercase throughout: `@type` casing is conventional, not guaranteed.
+
+_LOCAL_BUSINESS_TREE = {
+    # Direct subtypes of LocalBusiness.
+    "": (
+        "localbusiness", "animalshelter", "archiveorganization",
+        "automotivebusiness", "childcare", "dentist", "drycleaningorlaundry",
+        "emergencyservice", "employmentagency", "entertainmentbusiness",
+        "financialservice", "foodestablishment", "governmentoffice",
+        "healthandbeautybusiness", "homeandconstructionbusiness",
+        "internetcafe", "legalservice", "library", "lodgingbusiness",
+        "medicalbusiness", "professionalservice", "radiostation",
+        "realestateagent", "recyclingcenter", "selfstorage", "shoppingcenter",
+        "sportsactivitylocation", "store", "televisionstation",
+        "touristinformationcenter", "travelagency",
+    ),
+    "automotivebusiness": (
+        "autobodyshop", "autodealer", "autopartsstore", "autorental",
+        "autorepair", "autowash", "gasstation", "motorcycledealer",
+        "motorcyclerepair",
+    ),
+    "emergencyservice": ("firestation", "hospital", "policestation"),
+    "entertainmentbusiness": (
+        "adultentertainment", "amusementpark", "artgallery", "casino",
+        "comedyclub", "movietheater", "nightclub",
+    ),
+    "financialservice": (
+        "accountingservice", "automatedteller", "bankorcreditunion",
+        "insuranceagency",
+    ),
+    "foodestablishment": (
+        "bakery", "barorpub", "brewery", "cafeorcoffeeshop", "distillery",
+        "fastfoodrestaurant", "icecreamshop", "restaurant", "winery",
+    ),
+    "governmentoffice": ("postoffice",),
+    "healthandbeautybusiness": (
+        "beautysalon", "dayspa", "hairsalon", "healthclub", "nailsalon",
+        "tattooparlor",
+    ),
+    "homeandconstructionbusiness": (
+        "electrician", "generalcontractor", "housepainter", "hvacbusiness",
+        "locksmith", "movingcompany", "plumber", "roofingcontractor",
+    ),
+    "legalservice": ("attorney", "notary"),
+    "lodgingbusiness": (
+        "bedandbreakfast", "campground", "hostel", "hotel", "motel", "resort",
+        "skiresort",
+    ),
+    "medicalbusiness": (
+        "communityhealth", "covidtestingfacility", "dermatology",
+        "dietnutrition", "emergency", "geriatric", "gynecologic",
+        "individualphysician", "medicalclinic", "midwifery", "nursing",
+        "obstetric", "optician", "optometric", "otolaryngologic", "pediatric",
+        "pharmacy", "physician", "physiciansoffice", "physiotherapy",
+        "plasticsurgery", "podiatric", "primarycare", "psychiatric",
+        "publichealth", "veterinarycare",
+    ),
+    "sportsactivitylocation": (
+        "bowlingalley", "exercisegym", "golfcourse", "publicswimmingpool",
+        "sportsclub", "stadiumorarena", "tenniscomplex",
+    ),
+    "store": (
+        "bikestore", "bookstore", "clothingstore", "computerstore",
+        "conveniencestore", "departmentstore", "electronicsstore", "florist",
+        "furniturestore", "gardenstore", "grocerystore", "hardwarestore",
+        "hobbyshop", "homegoodsstore", "jewelrystore", "liquorstore",
+        "mensclothingstore", "mobilephonestore", "movierentalstore",
+        "musicstore", "officeequipmentstore", "outletstore", "pawnshop",
+        "petstore", "shoestore", "sportinggoodsstore", "tireshop", "toystore",
+        "wholesalestore",
+    ),
+}
+
+#: Every schema.org type that is a LocalBusiness or one of its subtypes,
+#: lowercased. `Organization` is deliberately absent: it is LocalBusiness's
+#: *parent*, and treating it as local would flag every company on the web.
+LOCAL_BUSINESS_TYPES = frozenset(
+    name for group in _LOCAL_BUSINESS_TREE.values() for name in group
+)
+
+#: Names that are *not* schema.org types but appear on real pages, mapped to
+#: what the author meant. `maps_checker.py` matched all five before the taxonomy
+#: moved here; keeping them means widening subtype coverage cannot narrow
+#: anything. Held apart from LOCAL_BUSINESS_TYPES so the set above stays an
+#: honest mirror of https://schema.org/LocalBusiness.
+LOCAL_BUSINESS_ALIASES = {
+    "autobody": "AutoBodyShop",
+    "barorsalon": "BarOrPub",
+    "cafe": "CafeOrCoffeeShop",
+    "gym": "ExerciseGym",
+    "selfstorge": "SelfStorage",
+}
+
+_LOCAL_BUSINESS_MATCH = LOCAL_BUSINESS_TYPES | frozenset(LOCAL_BUSINESS_ALIASES)
+
+_TYPE_VALUE_RE = re.compile(r'"@type"\s*:\s*(?:"([^"]*)"|\[([^\]]*)\])', re.I)
+_QUOTED_RE = re.compile(r'"([^"]*)"')
+
+
+def declared_types(html: str) -> List[str]:
+    """Every `@type` named in raw HTML, in document order, deduped case-insensitively.
+
+    Reads both shapes — `"@type": "Restaurant"` and `"@type": ["WebPage",
+    "Restaurant"]` — and returns the names as written, so callers can quote the
+    site's own casing back at the user.
+    """
+    found, seen = [], set()
+    for single, listed in _TYPE_VALUE_RE.findall(html or ""):
+        for name in ([single] if single else _QUOTED_RE.findall(listed)):
+            name = name.strip()
+            key = name.lower()
+            if key and key not in seen:
+                seen.add(key)
+                found.append(name)
+    return found
+
+
+def local_business_types_in(html: str) -> List[str]:
+    """LocalBusiness types declared in raw HTML, most-specific-first is not implied.
+
+    Empty for a publisher or SaaS page, which is what makes it safe to drive a
+    "you are missing LocalBusiness schema" finding off.
+    """
+    return [t for t in declared_types(html) if t.lower() in _LOCAL_BUSINESS_MATCH]
+
+
+def is_local_business(node) -> bool:
+    """True when a parsed node declares LocalBusiness or any of its subtypes."""
+    if not isinstance(node, dict):
+        return False
+    return any(t.lower() in _LOCAL_BUSINESS_MATCH for t in type_names(node.get("@type")))

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/local_signals_checker.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/local_signals_checker.py
@@ -45,7 +45,10 @@ def check_local_signals(url: str) -> dict:
     except Exception as e:
         return {"error": str(e), "url": url}
 
-    lb = jsonld.declares_type(html, "LocalBusiness")
+    # A subtype counts: Restaurant, Dentist and BookStore are all LocalBusiness,
+    # and schema.org asks for the most specific type available.
+    lb_types = jsonld.local_business_types_in(html)
+    lb = bool(lb_types)
     org = jsonld.declares_type(html, "Organization")
     website = jsonld.declares_type(html, "WebSite")
     tel = len(re.findall(r'href=["\']tel:', html, re.I))
@@ -65,7 +68,23 @@ def check_local_signals(url: str) -> dict:
     score = 40
     if lb:
         score += 35
-        recs.append("LocalBusiness JSON-LD detected — validate NAP consistency in references/local-seo.md.")
+        found = lb_types[0]
+        label = (
+            "LocalBusiness JSON-LD"
+            if found.lower() == "localbusiness"
+            else f"{found} JSON-LD (a LocalBusiness subtype)"
+        )
+        recs.append(f"{label} detected — validate NAP consistency in references/local-seo.md.")
+        for t in lb_types:
+            correction = jsonld.LOCAL_BUSINESS_ALIASES.get(t.lower())
+            if correction:
+                issues.append(
+                    {
+                        "severity": "medium",
+                        "finding": f"'{t}' is not a schema.org type — Google will ignore it.",
+                        "fix": f"Rename the @type to '{correction}'.",
+                    }
+                )
     elif has_local_indicators:
         issues.append(
             {
@@ -109,6 +128,7 @@ def check_local_signals(url: str) -> dict:
         "http_status": status,
         "likely_local_business": likely_local,
         "localbusiness_jsonld": lb,
+        "localbusiness_types": lb_types,
         "organization_jsonld": org,
         "has_local_indicators": has_local_indicators,
         "tel_links": tel,

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/maps_checker.py
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/scripts/maps_checker.py
@@ -20,6 +20,9 @@ import sys
 from typing import Any
 from urllib.parse import urlparse
 
+import jsonld
+from jsonld import LOCAL_BUSINESS_TYPES  # noqa: F401  (re-exported for callers)
+
 try:
     import requests
 except ImportError:
@@ -98,28 +101,14 @@ def _extract_jsonld_blocks(soup: BeautifulSoup) -> list[dict]:
 
 
 def _find_local_schemas(blocks: list[dict]) -> list[dict]:
-    """Return JSON-LD objects whose @type is LocalBusiness or a subtype."""
-    lb_types = {
-        "localbusiness", "restaurant", "dentist", "attorney", "autobody",
-        "autorepair", "bakery", "barorsalon", "beautysalon", "cafe",
-        "dentist", "drycleaningorlaundry", "electrician", "florist",
-        "gym", "hairsalon", "healthclub", "hotel", "insuranceagency",
-        "legalservice", "library", "locksmith", "medicalclinic", "motel",
-        "movingcompany", "notary", "optician", "petstore", "pharmacy",
-        "physician", "plumber", "realestateagent", "recyclingcenter",
-        "selfstorge", "shoppingcenter", "sportsclub", "store", "travelagency",
-        "veterinarycare",
-    }
-    results = []
-    for block in blocks:
-        block_type = block.get("@type", "")
-        if isinstance(block_type, list):
-            types = [t.lower() for t in block_type]
-        else:
-            types = [block_type.lower()]
-        if any(t in lb_types for t in types):
-            results.append(block)
-    return results
+    """Return JSON-LD objects whose @type is LocalBusiness or a subtype.
+
+    The taxonomy is shared with `local_signals_checker.py`. It used to live here
+    as a private copy, which drifted: it carried a `selfstorge` typo and a
+    `barorsalon` type schema.org has never defined, and it was the *only* script
+    that knew about subtypes at all.
+    """
+    return [b for b in blocks if jsonld.is_local_business(b)]
 
 
 def _audit_schema_completeness(schema: dict) -> list[dict]:
@@ -267,8 +256,8 @@ def check_maps(url: str) -> dict:
     status = fetched["status"]
     soup = BeautifulSoup(html, "html.parser")
 
-    jsonld = _extract_jsonld_blocks(soup)
-    local_schemas = _find_local_schemas(jsonld)
+    blocks = _extract_jsonld_blocks(soup)
+    local_schemas = _find_local_schemas(blocks)
 
     schema_issues: list[dict] = []
     schema_fields_summary: list[dict] = []

--- a/scripts/jsonld.py
+++ b/scripts/jsonld.py
@@ -15,9 +15,12 @@ Deliberately dependency-free, stdlib only: `faq_parity.py` and
 `validate_schema.py` are regex/json by design and must not acquire a
 BeautifulSoup dependency through the back door.
 
-Note on scope: this module knows about JSON-LD *shapes* only. Which types are
-retired or no longer produce rich results stays in each script as a
-module-level constant, pinned to `references/schema-types.md` by
+Note on scope: this module knows about JSON-LD *shapes*, plus the one piece of
+schema.org taxonomy two scripts both need — the LocalBusiness subtype tree,
+which is a fixed fact about the vocabulary rather than a judgement about it.
+Which types are retired or no longer produce rich results is a judgement, moves
+with Google's announcements, and stays in each script as a module-level
+constant, pinned to `references/schema-types.md` by
 `tests/test_schema_status_parity.py` (decision D-017).
 """
 
@@ -75,3 +78,145 @@ def declares_type(html: str, wanted: str) -> bool:
     escaped = re.escape(wanted)
     pattern = r'"@type"\s*:\s*(?:"%s"|\[[^\]]*"%s")' % (escaped, escaped)
     return bool(re.search(pattern, html or "", re.I))
+
+
+# --- schema.org LocalBusiness hierarchy -------------------------------------
+#
+# A page marked up as `Restaurant` or `Dentist` *is* marked up as a
+# LocalBusiness; schema.org's own guidance is to use the most specific subtype
+# available. Matching the literal string "LocalBusiness" and nothing else told
+# every correctly-marked-up local business, at high severity, to add the schema
+# it already had.
+#
+# Grouped by parent to stay checkable against https://schema.org/LocalBusiness.
+# Lowercase throughout: `@type` casing is conventional, not guaranteed.
+
+_LOCAL_BUSINESS_TREE = {
+    # Direct subtypes of LocalBusiness.
+    "": (
+        "localbusiness", "animalshelter", "archiveorganization",
+        "automotivebusiness", "childcare", "dentist", "drycleaningorlaundry",
+        "emergencyservice", "employmentagency", "entertainmentbusiness",
+        "financialservice", "foodestablishment", "governmentoffice",
+        "healthandbeautybusiness", "homeandconstructionbusiness",
+        "internetcafe", "legalservice", "library", "lodgingbusiness",
+        "medicalbusiness", "professionalservice", "radiostation",
+        "realestateagent", "recyclingcenter", "selfstorage", "shoppingcenter",
+        "sportsactivitylocation", "store", "televisionstation",
+        "touristinformationcenter", "travelagency",
+    ),
+    "automotivebusiness": (
+        "autobodyshop", "autodealer", "autopartsstore", "autorental",
+        "autorepair", "autowash", "gasstation", "motorcycledealer",
+        "motorcyclerepair",
+    ),
+    "emergencyservice": ("firestation", "hospital", "policestation"),
+    "entertainmentbusiness": (
+        "adultentertainment", "amusementpark", "artgallery", "casino",
+        "comedyclub", "movietheater", "nightclub",
+    ),
+    "financialservice": (
+        "accountingservice", "automatedteller", "bankorcreditunion",
+        "insuranceagency",
+    ),
+    "foodestablishment": (
+        "bakery", "barorpub", "brewery", "cafeorcoffeeshop", "distillery",
+        "fastfoodrestaurant", "icecreamshop", "restaurant", "winery",
+    ),
+    "governmentoffice": ("postoffice",),
+    "healthandbeautybusiness": (
+        "beautysalon", "dayspa", "hairsalon", "healthclub", "nailsalon",
+        "tattooparlor",
+    ),
+    "homeandconstructionbusiness": (
+        "electrician", "generalcontractor", "housepainter", "hvacbusiness",
+        "locksmith", "movingcompany", "plumber", "roofingcontractor",
+    ),
+    "legalservice": ("attorney", "notary"),
+    "lodgingbusiness": (
+        "bedandbreakfast", "campground", "hostel", "hotel", "motel", "resort",
+        "skiresort",
+    ),
+    "medicalbusiness": (
+        "communityhealth", "covidtestingfacility", "dermatology",
+        "dietnutrition", "emergency", "geriatric", "gynecologic",
+        "individualphysician", "medicalclinic", "midwifery", "nursing",
+        "obstetric", "optician", "optometric", "otolaryngologic", "pediatric",
+        "pharmacy", "physician", "physiciansoffice", "physiotherapy",
+        "plasticsurgery", "podiatric", "primarycare", "psychiatric",
+        "publichealth", "veterinarycare",
+    ),
+    "sportsactivitylocation": (
+        "bowlingalley", "exercisegym", "golfcourse", "publicswimmingpool",
+        "sportsclub", "stadiumorarena", "tenniscomplex",
+    ),
+    "store": (
+        "bikestore", "bookstore", "clothingstore", "computerstore",
+        "conveniencestore", "departmentstore", "electronicsstore", "florist",
+        "furniturestore", "gardenstore", "grocerystore", "hardwarestore",
+        "hobbyshop", "homegoodsstore", "jewelrystore", "liquorstore",
+        "mensclothingstore", "mobilephonestore", "movierentalstore",
+        "musicstore", "officeequipmentstore", "outletstore", "pawnshop",
+        "petstore", "shoestore", "sportinggoodsstore", "tireshop", "toystore",
+        "wholesalestore",
+    ),
+}
+
+#: Every schema.org type that is a LocalBusiness or one of its subtypes,
+#: lowercased. `Organization` is deliberately absent: it is LocalBusiness's
+#: *parent*, and treating it as local would flag every company on the web.
+LOCAL_BUSINESS_TYPES = frozenset(
+    name for group in _LOCAL_BUSINESS_TREE.values() for name in group
+)
+
+#: Names that are *not* schema.org types but appear on real pages, mapped to
+#: what the author meant. `maps_checker.py` matched all five before the taxonomy
+#: moved here; keeping them means widening subtype coverage cannot narrow
+#: anything. Held apart from LOCAL_BUSINESS_TYPES so the set above stays an
+#: honest mirror of https://schema.org/LocalBusiness.
+LOCAL_BUSINESS_ALIASES = {
+    "autobody": "AutoBodyShop",
+    "barorsalon": "BarOrPub",
+    "cafe": "CafeOrCoffeeShop",
+    "gym": "ExerciseGym",
+    "selfstorge": "SelfStorage",
+}
+
+_LOCAL_BUSINESS_MATCH = LOCAL_BUSINESS_TYPES | frozenset(LOCAL_BUSINESS_ALIASES)
+
+_TYPE_VALUE_RE = re.compile(r'"@type"\s*:\s*(?:"([^"]*)"|\[([^\]]*)\])', re.I)
+_QUOTED_RE = re.compile(r'"([^"]*)"')
+
+
+def declared_types(html: str) -> List[str]:
+    """Every `@type` named in raw HTML, in document order, deduped case-insensitively.
+
+    Reads both shapes — `"@type": "Restaurant"` and `"@type": ["WebPage",
+    "Restaurant"]` — and returns the names as written, so callers can quote the
+    site's own casing back at the user.
+    """
+    found, seen = [], set()
+    for single, listed in _TYPE_VALUE_RE.findall(html or ""):
+        for name in ([single] if single else _QUOTED_RE.findall(listed)):
+            name = name.strip()
+            key = name.lower()
+            if key and key not in seen:
+                seen.add(key)
+                found.append(name)
+    return found
+
+
+def local_business_types_in(html: str) -> List[str]:
+    """LocalBusiness types declared in raw HTML, most-specific-first is not implied.
+
+    Empty for a publisher or SaaS page, which is what makes it safe to drive a
+    "you are missing LocalBusiness schema" finding off.
+    """
+    return [t for t in declared_types(html) if t.lower() in _LOCAL_BUSINESS_MATCH]
+
+
+def is_local_business(node) -> bool:
+    """True when a parsed node declares LocalBusiness or any of its subtypes."""
+    if not isinstance(node, dict):
+        return False
+    return any(t.lower() in _LOCAL_BUSINESS_MATCH for t in type_names(node.get("@type")))

--- a/scripts/local_signals_checker.py
+++ b/scripts/local_signals_checker.py
@@ -45,7 +45,10 @@ def check_local_signals(url: str) -> dict:
     except Exception as e:
         return {"error": str(e), "url": url}
 
-    lb = jsonld.declares_type(html, "LocalBusiness")
+    # A subtype counts: Restaurant, Dentist and BookStore are all LocalBusiness,
+    # and schema.org asks for the most specific type available.
+    lb_types = jsonld.local_business_types_in(html)
+    lb = bool(lb_types)
     org = jsonld.declares_type(html, "Organization")
     website = jsonld.declares_type(html, "WebSite")
     tel = len(re.findall(r'href=["\']tel:', html, re.I))
@@ -65,7 +68,23 @@ def check_local_signals(url: str) -> dict:
     score = 40
     if lb:
         score += 35
-        recs.append("LocalBusiness JSON-LD detected — validate NAP consistency in references/local-seo.md.")
+        found = lb_types[0]
+        label = (
+            "LocalBusiness JSON-LD"
+            if found.lower() == "localbusiness"
+            else f"{found} JSON-LD (a LocalBusiness subtype)"
+        )
+        recs.append(f"{label} detected — validate NAP consistency in references/local-seo.md.")
+        for t in lb_types:
+            correction = jsonld.LOCAL_BUSINESS_ALIASES.get(t.lower())
+            if correction:
+                issues.append(
+                    {
+                        "severity": "medium",
+                        "finding": f"'{t}' is not a schema.org type — Google will ignore it.",
+                        "fix": f"Rename the @type to '{correction}'.",
+                    }
+                )
     elif has_local_indicators:
         issues.append(
             {
@@ -109,6 +128,7 @@ def check_local_signals(url: str) -> dict:
         "http_status": status,
         "likely_local_business": likely_local,
         "localbusiness_jsonld": lb,
+        "localbusiness_types": lb_types,
         "organization_jsonld": org,
         "has_local_indicators": has_local_indicators,
         "tel_links": tel,

--- a/scripts/maps_checker.py
+++ b/scripts/maps_checker.py
@@ -20,6 +20,9 @@ import sys
 from typing import Any
 from urllib.parse import urlparse
 
+import jsonld
+from jsonld import LOCAL_BUSINESS_TYPES  # noqa: F401  (re-exported for callers)
+
 try:
     import requests
 except ImportError:
@@ -98,28 +101,14 @@ def _extract_jsonld_blocks(soup: BeautifulSoup) -> list[dict]:
 
 
 def _find_local_schemas(blocks: list[dict]) -> list[dict]:
-    """Return JSON-LD objects whose @type is LocalBusiness or a subtype."""
-    lb_types = {
-        "localbusiness", "restaurant", "dentist", "attorney", "autobody",
-        "autorepair", "bakery", "barorsalon", "beautysalon", "cafe",
-        "dentist", "drycleaningorlaundry", "electrician", "florist",
-        "gym", "hairsalon", "healthclub", "hotel", "insuranceagency",
-        "legalservice", "library", "locksmith", "medicalclinic", "motel",
-        "movingcompany", "notary", "optician", "petstore", "pharmacy",
-        "physician", "plumber", "realestateagent", "recyclingcenter",
-        "selfstorge", "shoppingcenter", "sportsclub", "store", "travelagency",
-        "veterinarycare",
-    }
-    results = []
-    for block in blocks:
-        block_type = block.get("@type", "")
-        if isinstance(block_type, list):
-            types = [t.lower() for t in block_type]
-        else:
-            types = [block_type.lower()]
-        if any(t in lb_types for t in types):
-            results.append(block)
-    return results
+    """Return JSON-LD objects whose @type is LocalBusiness or a subtype.
+
+    The taxonomy is shared with `local_signals_checker.py`. It used to live here
+    as a private copy, which drifted: it carried a `selfstorge` typo and a
+    `barorsalon` type schema.org has never defined, and it was the *only* script
+    that knew about subtypes at all.
+    """
+    return [b for b in blocks if jsonld.is_local_business(b)]
 
 
 def _audit_schema_completeness(schema: dict) -> list[dict]:
@@ -267,8 +256,8 @@ def check_maps(url: str) -> dict:
     status = fetched["status"]
     soup = BeautifulSoup(html, "html.parser")
 
-    jsonld = _extract_jsonld_blocks(soup)
-    local_schemas = _find_local_schemas(jsonld)
+    blocks = _extract_jsonld_blocks(soup)
+    local_schemas = _find_local_schemas(blocks)
 
     schema_issues: list[dict] = []
     schema_fields_summary: list[dict] = []

--- a/tests/test_local_business_subtypes.py
+++ b/tests/test_local_business_subtypes.py
@@ -1,0 +1,248 @@
+"""A LocalBusiness subtype *is* a LocalBusiness.
+
+`local_signals_checker.py` matched the exact string "LocalBusiness" and nothing
+else, so a restaurant, dentist or bookshop carrying correct, specific schema was
+told at **high** severity to add the markup it already had — the worst kind of
+finding, because it reads as authoritative and sends the user to break a working
+page. `maps_checker.py` had known the subtype list all along; the two scripts
+simply disagreed about what counts as a local business.
+
+The taxonomy now lives once in `scripts/jsonld.py` and both scripts read it.
+
+Same defect family as `test_audit_script_crashes.py`: a script assuming the one
+shape it happened to see first. This one never raised — it returned a confident
+wrong answer.
+"""
+
+import json
+import os
+import re
+import sys
+
+import pytest
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+sys.path.insert(0, os.path.join(ROOT, "scripts"))
+
+import jsonld  # noqa: E402
+import local_signals_checker  # noqa: E402
+import maps_checker  # noqa: E402
+
+DOC = os.path.join(ROOT, "references", "local-seo.md")
+
+
+def _page(type_value, *, tel=True, address=True):
+    """A page with real local indicators and one JSON-LD block."""
+    block = json.dumps({"@context": "https://schema.org", "@type": type_value,
+                        "name": "Acme"})
+    parts = [f'<script type="application/ld+json">{block}</script>']
+    if tel:
+        parts.append('<a href="tel:+15555550123">Call us</a>')
+    if address:
+        parts.append('<span itemprop="streetAddress">1 Main St</span>')
+    return "<html><body>" + "".join(parts) + "</body></html>"
+
+
+# --- the taxonomy itself ----------------------------------------------------
+
+def test_localbusiness_itself_is_in_the_set():
+    assert "localbusiness" in jsonld.LOCAL_BUSINESS_TYPES
+
+
+def test_set_is_lowercase_for_case_insensitive_matching():
+    assert all(t == t.lower() for t in jsonld.LOCAL_BUSINESS_TYPES)
+
+
+def test_organization_is_not_a_local_business():
+    """Organization is LocalBusiness's *parent*, not a subtype."""
+    for parent in ("organization", "corporation", "person", "webpage",
+                   "product", "article"):
+        assert parent not in jsonld.LOCAL_BUSINESS_TYPES
+
+
+@pytest.mark.parametrize("subtype", [
+    "Restaurant", "Dentist", "Plumber", "BookStore", "Hotel", "Attorney",
+    "Bakery", "HairSalon", "AutoRepair", "Pharmacy", "Store", "Electrician",
+])
+def test_common_subtypes_are_recognised(subtype):
+    assert subtype.lower() in jsonld.LOCAL_BUSINESS_TYPES
+
+
+def test_reference_doc_and_code_agree():
+    """The five subtypes named in references/local-seo.md must all be known.
+
+    Docs and code drift silently otherwise; this is the same pinning the
+    retired-type sets get in test_schema_status_parity.py (D-017).
+    """
+    with open(DOC, encoding="utf-8") as fh:
+        line = [ln for ln in fh if "more specific than generic" in ln]
+    assert line, f"subtype line not found in {DOC}"
+    named = re.findall(r"`([A-Za-z]+)`", line[0].split("→")[0])
+    assert len(named) >= 5, named
+    for t in named:
+        assert t.lower() in jsonld.LOCAL_BUSINESS_TYPES, f"{t} documented but unknown"
+
+
+# --- detection helpers ------------------------------------------------------
+
+def test_declared_types_reads_both_shapes():
+    html = ('<script type="application/ld+json">{"@type": "Restaurant"}</script>'
+            '<script type="application/ld+json">{"@type": ["WebPage", "Dentist"]}</script>')
+    assert jsonld.declared_types(html) == ["Restaurant", "WebPage", "Dentist"]
+
+
+def test_declared_types_dedupes_case_insensitively():
+    html = '{"@type":"Store"} {"@type":"store"} {"@type":"Store"}'
+    assert jsonld.declared_types(html) == ["Store"]
+
+
+def test_local_business_types_in_filters_to_the_taxonomy():
+    html = '{"@type": ["WebPage", "Restaurant", "Organization"]}'
+    assert jsonld.local_business_types_in(html) == ["Restaurant"]
+
+
+def test_local_business_types_in_returns_empty_for_a_saas_page():
+    html = '{"@type": ["WebSite", "Organization", "SoftwareApplication"]}'
+    assert jsonld.local_business_types_in(html) == []
+
+
+def test_is_local_business_on_a_parsed_node():
+    assert jsonld.is_local_business({"@type": "Restaurant"}) is True
+    assert jsonld.is_local_business({"@type": ["WebPage", "Bakery"]}) is True
+    assert jsonld.is_local_business({"@type": "Organization"}) is False
+    assert jsonld.is_local_business("not a node") is False
+    assert jsonld.is_local_business({}) is False
+
+
+def test_declares_type_stays_exact():
+    """The generic helper must NOT gain subtype awareness.
+
+    Callers asking for a literal @type (retired-type checks, FAQPage parity)
+    depend on it meaning exactly what it says.
+    """
+    html = '{"@type": "Restaurant"}'
+    assert jsonld.declares_type(html, "LocalBusiness") is False
+
+
+# --- the finding that started this -----------------------------------------
+
+@pytest.mark.parametrize("type_value", [
+    "Restaurant",
+    "Dentist",
+    "Plumber",
+    ["WebPage", "Restaurant"],
+    ["Store", "Organization"],
+])
+def test_subtype_page_is_not_told_to_add_schema(type_value, monkeypatch):
+    result = _check(monkeypatch, _page(type_value))
+    assert result["localbusiness_jsonld"] is True
+    findings = [i["finding"] for i in result["issues"]]
+    assert not any("no LocalBusiness JSON-LD" in f for f in findings), findings
+    assert not any("add LocalBusiness schema" in r for r in result["recommendations"])
+
+
+def test_subtype_is_named_in_the_output(monkeypatch):
+    result = _check(monkeypatch, _page("Restaurant"))
+    assert result["localbusiness_types"] == ["Restaurant"]
+    assert any("Restaurant" in r for r in result["recommendations"])
+
+
+def test_plain_localbusiness_still_detected(monkeypatch):
+    result = _check(monkeypatch, _page("LocalBusiness"))
+    assert result["localbusiness_jsonld"] is True
+    assert result["localbusiness_types"] == ["LocalBusiness"]
+
+
+def test_local_indicators_without_any_schema_still_flagged(monkeypatch):
+    """The real finding must survive: this is the case it exists for."""
+    html = '<html><body><a href="tel:+15555550123">Call</a>'\
+           '<span>streetAddress</span></body></html>'
+    result = _check(monkeypatch, html)
+    assert result["localbusiness_jsonld"] is False
+    assert result["localbusiness_types"] == []
+    assert any(i["severity"] == "high" for i in result["issues"])
+
+
+def test_saas_page_is_still_not_a_local_business(monkeypatch):
+    html = ('<html><body><script type="application/ld+json">'
+            '{"@type": ["WebSite", "Organization"]}</script></body></html>')
+    result = _check(monkeypatch, html)
+    assert result["likely_local_business"] is False
+    assert result["score"] is None
+    assert result["issues"] == []
+
+
+# --- non-standard spellings: widening must not narrow -----------------------
+
+# Exactly what maps_checker.py's private set matched before the taxonomy moved
+# into jsonld.py. Every one of these must still be detected, or this "fix"
+# quietly removed coverage from the one script that already had it.
+MAPS_CHECKER_SET_BEFORE = frozenset({
+    "localbusiness", "restaurant", "dentist", "attorney", "autobody",
+    "autorepair", "bakery", "barorsalon", "beautysalon", "cafe",
+    "drycleaningorlaundry", "electrician", "florist", "gym", "hairsalon",
+    "healthclub", "hotel", "insuranceagency", "legalservice", "library",
+    "locksmith", "medicalclinic", "motel", "movingcompany", "notary",
+    "optician", "petstore", "pharmacy", "physician", "plumber",
+    "realestateagent", "recyclingcenter", "selfstorge", "shoppingcenter",
+    "sportsclub", "store", "travelagency", "veterinarycare",
+})
+
+
+@pytest.mark.parametrize("old_type", sorted(MAPS_CHECKER_SET_BEFORE))
+def test_nothing_maps_checker_used_to_match_is_lost(old_type):
+    assert jsonld.is_local_business({"@type": old_type}) is True
+
+
+def test_aliases_are_kept_out_of_the_schema_org_set():
+    """LOCAL_BUSINESS_TYPES must stay an honest mirror of schema.org."""
+    for bad in jsonld.LOCAL_BUSINESS_ALIASES:
+        assert bad not in jsonld.LOCAL_BUSINESS_TYPES
+
+
+def test_every_alias_points_at_a_real_type():
+    for bad, correction in jsonld.LOCAL_BUSINESS_ALIASES.items():
+        assert correction.lower() in jsonld.LOCAL_BUSINESS_TYPES, bad
+
+
+def test_alias_is_detected_but_reported_as_invalid(monkeypatch):
+    result = _check(monkeypatch, _page("Cafe"))
+    assert result["localbusiness_jsonld"] is True
+    fixes = [i["fix"] for i in result["issues"]]
+    assert any("CafeOrCoffeeShop" in f for f in fixes), result["issues"]
+
+
+def test_valid_subtype_gets_no_invalid_type_issue(monkeypatch):
+    result = _check(monkeypatch, _page("Restaurant"))
+    assert not any("not a schema.org type" in i["finding"] for i in result["issues"])
+
+
+# --- the two scripts must not disagree again --------------------------------
+
+@pytest.mark.parametrize("subtype", ["Restaurant", "Dentist", "Store", "Hotel"])
+def test_maps_checker_and_local_signals_agree(subtype):
+    """Both scripts read the same taxonomy, so they cannot drift apart."""
+    node = {"@type": subtype, "name": "Acme"}
+    assert bool(maps_checker._find_local_schemas([node])) is True
+    assert jsonld.is_local_business(node) is True
+
+
+def test_maps_checker_reads_the_shared_taxonomy():
+    assert maps_checker.LOCAL_BUSINESS_TYPES is jsonld.LOCAL_BUSINESS_TYPES
+
+
+# --- helper -----------------------------------------------------------------
+
+class _Resp:
+    status_code = 200
+
+    def __init__(self, text):
+        self.text = text
+
+
+def _check(monkeypatch, html):
+    monkeypatch.setattr(
+        local_signals_checker.requests, "get",
+        lambda *a, **k: _Resp(html),
+    )
+    return local_signals_checker.check_local_signals("https://example.com")


### PR DESCRIPTION
`local_signals_checker.py` matched the literal `@type` **"LocalBusiness"** and nothing else. A restaurant, dentist, plumber or bookshop carrying correct, *more specific* schema — the markup schema.org actually asks for — was told at **high** severity to add the schema it already had.

`maps_checker.py` had known the subtype list since it was written, in a private set. The two scripts simply disagreed about what a local business is.

```
jsonld.declares_type('{"@type":"Restaurant"}', "LocalBusiness")  ->  False   # before
```

## The change

The taxonomy now lives once in `scripts/jsonld.py` as `LOCAL_BUSINESS_TYPES` — 149 types grouped by parent so it stays checkable against [schema.org/LocalBusiness](https://schema.org/LocalBusiness) — and both scripts read it, so they cannot drift apart again.

- `scripts/jsonld.py` — the taxonomy plus `declared_types()`, `local_business_types_in()`, `is_local_business()`
- `scripts/local_signals_checker.py` — the false finding is gone; output gains `localbusiness_types`, and the recommendation names the subtype it found rather than saying "LocalBusiness" back at a page that says "Restaurant"
- `scripts/maps_checker.py` — private set deleted, `_find_local_schemas` is now one line

`declares_type()` deliberately **stays exact-match**. The retired-type checks and FAQPage parity depend on it meaning literally what it says; a test pins that.

## Widening a set can narrow it

`maps_checker`'s private set held five names schema.org has never defined:

| in the old set | what was meant |
|---|---|
| `Cafe` | `CafeOrCoffeeShop` |
| `Gym` | `ExerciseGym` |
| `AutoBody` | `AutoBodyShop` |
| `BarOrSalon` | `BarOrPub` |
| `selfstorge` | `SelfStorage` (typo) |

Deleting the set outright would have silently *removed* detection for pages using those spellings — a fix that only widens, quietly narrowing. They are kept as `LOCAL_BUSINESS_ALIASES`, held apart from the schema.org set so that set stays an honest mirror. Coverage is a strict superset of before, and a page using one now gets a medium finding naming the real type instead of silent acceptance.

## Verification

- **`tests/test_local_business_subtypes.py`, 78 tests. Suite 300 → 378.**
- Validated by reintroducing the defect — taxonomy shrunk back to `{"localbusiness"}` — which fails 25 of them.
- A parametrised test pins **every type `maps_checker` matched before this change**, so the alias tolerance cannot be dropped by accident.
- `check-plugin-sync.py` and `check_version_sync.py` green at 1.12.7 after `bash setup-plugin.sh`.
- End-to-end CLI against a local server: a `Restaurant` page scores 95 with zero issues and reports `localbusiness_types: ["Restaurant"]`; a `Cafe` page is detected and told to rename `@type` to `CafeOrCoffeeShop`.

`maps_checker.py` has no live smoke test here — `fetch_page` has an SSRF guard that blocks private IPs, so localhost is unreachable. Its coverage is the unit tests.

Same defect family as #44, and the one item that PR knowingly left behind. This one never raised — it returned a confident wrong answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
