### PR TITLE
chore: release 1.12.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
     "name": "Myk Pono"
   },
   "metadata": {
-    "version": "1.12.7"
+    "version": "1.12.8"
   },
   "plugins": [
     {
       "name": "ultimate-seo-geo",
       "description": "Scored SEO audits for developers/marketers using AI agents: technical health, JSON-LD, E-E-A-T, backlinks, GEO (AI Overviews, ChatGPT, Perplexity). 46 scripts; HTML/Excel/PDF. E-commerce schema, drift monitoring, topic clustering, Google API tiers, maps intelligence. Optional MCP (Firecrawl, DataForSEO). Parallel workers: agents/PARALLEL-AUDIT.md. Modes: Audit → Plan → Execute.",
-      "version": "1.12.7",
+      "version": "1.12.8",
       "author": {
         "name": "Myk Pono",
         "url": "https://lab.mykpono.com"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.7 |
+| **Version** | 1.12.8 |
 | **Updated** | 2026-08-22 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [1.12.8] - 2026-08-25
+
+The one defect v1.12.7 knowingly left behind, and the last of the family: a script that assumed the
+shape it happened to see first. This one never raised. It returned a confident wrong answer, at
+**high** severity, to exactly the users whose markup was already right.
+
 ### Fixed
 
 - **A LocalBusiness subtype now counts as a LocalBusiness.** `local_signals_checker.py` matched the
@@ -23,8 +31,7 @@
 - `local_signals_checker.py` output gains `localbusiness_types`, and its recommendation names the
   subtype it found rather than saying "LocalBusiness" back at a page that says "Restaurant".
 - `tests/test_local_business_subtypes.py` (78 tests; suite 300 -> 378), including a parametrised
-  guard that every type
-  `maps_checker.py` matched before this change is still matched.
+  guard that every type `maps_checker.py` matched before this change is still matched.
 
 ## [1.12.7] - 2026-08-24
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![AGENTS.md](https://img.shields.io/badge/AGENTS.md-compatible-blue)](https://agents.md)
-[![Version](https://img.shields.io/badge/version-1.12.7-green.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.12.8-green.svg)](CHANGELOG.md)
 [![LLM-Agnostic](https://img.shields.io/badge/LLM--Agnostic-7%2B%20platforms-purple.svg)](#platform-compatibility)
 
 The definitive SEO and Generative Engine Optimization agent for AI coding tools. LLM-agnostic — works on any platform that reads `AGENTS.md`. Runs full site audits with scored findings, generates ready-to-deploy fixes, and optimizes content for both Google Search and AI search engines (Google AI Overviews, AI Mode, ChatGPT Search, Perplexity). Exports HTML, Excel, and PDF reports.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ultimate-seo-geo
 description: Audits and optimizes websites for search engine visibility (SEO) and AI search citation (GEO), covering technical health, E-E-A-T content scoring, domain authority, structured data, rich results, and entity signals. Use when running SEO audits, diagnosing traffic drops or ranking losses, generating Schema.org JSON-LD, checking Core Web Vitals, crawlability, robots.txt, sitemaps, hreflang, backlinks, planning content strategy or site migrations, fixing indexing issues, or optimizing for AI Overviews, ChatGPT, and Perplexity. NOT for paid ads (PPC/SEM), social media strategy, email marketing, or general web development unrelated to search.
-version: 1.12.7
+version: 1.12.8
 ---
 
 # Ultimate SEO + GEO — LLM-Agnostic SEO Agent
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.7 |
+| **Version** | 1.12.8 |
 | **Updated** | 2026-08-12 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/plugins/ultimate-seo-geo/.claude-plugin/plugin.json
+++ b/plugins/ultimate-seo-geo/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ultimate-seo-geo",
   "description": "Scored SEO audits for developers and marketers using AI agents: technical health, Schema.org JSON-LD, E-E-A-T, backlinks, domain signals, GEO (AI Overviews, ChatGPT, Perplexity). 46 bundled scripts; HTML/Excel/PDF reports. E-commerce schema, drift monitoring, topic clustering, Google API tiers (GSC/GA4), maps intelligence. Optional MCP (Firecrawl, DataForSEO): references/optional-extensions-mcp.md. Modes: Audit → Plan → Execute.",
-  "version": "1.12.7",
+  "version": "1.12.8",
   "author": {
     "name": "Myk Pono",
     "url": "https://lab.mykpono.com"

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/AGENTS.md
@@ -2,7 +2,7 @@
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.7 |
+| **Version** | 1.12.8 |
 | **Updated** | 2026-08-22 |
 | **License** | MIT |
 | **Author** | Myk Pono |

--- a/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/SKILL.md
+++ b/plugins/ultimate-seo-geo/skills/ultimate-seo-geo/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ultimate-seo-geo
 description: Audits and optimizes websites for search engine visibility (SEO) and AI search citation (GEO), covering technical health, E-E-A-T content scoring, domain authority, structured data, rich results, and entity signals. Use when running SEO audits, diagnosing traffic drops or ranking losses, generating Schema.org JSON-LD, checking Core Web Vitals, crawlability, robots.txt, sitemaps, hreflang, backlinks, planning content strategy or site migrations, fixing indexing issues, or optimizing for AI Overviews, ChatGPT, and Perplexity. NOT for paid ads (PPC/SEM), social media strategy, email marketing, or general web development unrelated to search.
-version: 1.12.7
+version: 1.12.8
 ---
 
 # Ultimate SEO + GEO — LLM-Agnostic SEO Agent
 
 | Attribute | Details |
 | --- | --- |
-| **Version** | 1.12.7 |
+| **Version** | 1.12.8 |
 | **Updated** | 2026-08-12 |
 | **License** | MIT |
 | **Author** | Myk Pono |


### PR DESCRIPTION
Folds the `[Unreleased]` entry into `[1.12.8] - 2026-08-25` and bumps the version across all **10 references in 7 files**.

Ships [#46](https://github.com/mykpono/ultimate-seo-geo/pull/46) — the one defect v1.12.7 knowingly left behind, and the last of that family. A LocalBusiness subtype now counts as a LocalBusiness, so a restaurant, dentist, plumber or bookshop with correct, more specific schema is no longer told at **high** severity to add the markup it already had.

## Why patch, not minor

One behaviour fix, on the precedent of 1.12.7 which carried eight and was a patch. The new `jsonld` helpers are internal plumbing, and `localbusiness_types` is an additive output key. Say the word if you'd rather this were 1.13.0 — nothing is tagged yet.

## Verification

- 378 passing
- `check_version_sync.py` → all 7 checked references at 1.12.8
- `check-plugin-sync.py` → root tree and plugin bundle byte-identical
- No `1.12.7` left anywhere outside `CHANGELOG.md` history
- The release-notes `sed` extraction against `## [1.12.8]` returns 1,846 chars, not an empty body

## After merge

This repo's tag trap has fired three times — v1.12.2, v1.12.3, v1.12.7 — always the same way: tagging before pulling the merge, so the tag points at a tree self-reporting the *previous* version, and the CHANGELOG `sed` silently finds no section and publishes an empty release body.

```
git checkout main && git pull --ff-only
python3 scripts/check_tag_matches_version.py v1.12.8
```

Only then tag and publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
